### PR TITLE
Makes SDocuments serializable. Note, that this commit depends on the

### DIFF
--- a/annis-gui/pom.xml
+++ b/annis-gui/pom.xml
@@ -116,19 +116,19 @@
                 <artifactItem>
                   <groupId>de.hu_berlin.german.korpling.saltnpepper</groupId>
                   <artifactId>salt-saltCommon</artifactId>
-                  <version>1.1.7</version>
+                  <version>1.1.8-SNAPSHOT</version>
                   <type>bundle</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>de.hu_berlin.german.korpling.saltnpepper</groupId>
                   <artifactId>salt-graph</artifactId>
-                  <version>1.1.7</version>
+                  <version>1.1.8-SNAPSHOT</version>
                   <type>bundle</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>de.hu_berlin.german.korpling.saltnpepper</groupId>
                   <artifactId>salt-saltCore</artifactId>
-                  <version>1.1.7</version>
+                  <version>1.1.8-SNAPSHOT</version>
                   <type>bundle</type>
                 </artifactItem>
               </artifactItems>

--- a/annis-gui/src/main/java/annis/gui/resultview/SingleResultPanel.java
+++ b/annis-gui/src/main/java/annis/gui/resultview/SingleResultPanel.java
@@ -86,7 +86,7 @@ public class SingleResultPanel extends CssLayout implements
   private static final ThemeResource ICON_RESOURCE = new ThemeResource(
     "info.gif");
 
-  private transient SDocument result;
+  private SDocument result;
 
   private Map<String, String> markedCoveredMap;
 

--- a/annis-gui/src/main/java/annis/gui/resultview/VisualizerPanel.java
+++ b/annis-gui/src/main/java/annis/gui/resultview/VisualizerPanel.java
@@ -100,7 +100,7 @@ public class VisualizerPanel extends CssLayout
 
   private Component vis;
 
-  private transient SDocument result;
+  private SDocument result;
 
   private PluginSystem ps;
 

--- a/annis-interfaces/pom.xml
+++ b/annis-interfaces/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>de.hu_berlin.german.korpling.saltnpepper</groupId>
       <artifactId>salt-saltCommon</artifactId>
-      <version>1.1.7</version>
+      <version>1.1.8-SNAPSHOT</version>
       <type>bundle</type>
       <exclusions>
         <exclusion>  

--- a/annis-interfaces/src/main/java/annis/CommonHelper.java
+++ b/annis-interfaces/src/main/java/annis/CommonHelper.java
@@ -424,8 +424,8 @@ public class CommonHelper
     XMIResourceImpl res = new XMIResourceImpl();
     res.getContents().add(doc);
     
-    // also add the SDocumentGraph of the document
-    res.getContents().add(doc.getSDocumentGraph());
+   // also add the SDocumentGraph of the document
+//    res.getContents().add(doc.getSDocumentGraph());
     
     res.save(out, res.getDefaultSaveOptions());
   }


### PR DESCRIPTION
salt version > 1.1.8-SNAPHSOT. When you merge this commit back to the
development branch, you should change the pom.xml salt dependencies
back to a stable version. The only thing to merge is the remove of the transient modifier. 

closes #288
