### PR TITLE
Removed progress bar from result view panel

### DIFF
--- a/annis-gui/src/main/java/annis/gui/controlpanel/QueryPanel.java
+++ b/annis-gui/src/main/java/annis/gui/controlpanel/QueryPanel.java
@@ -39,8 +39,6 @@ import com.vaadin.event.ShortcutAction.ModifierKey;
 import com.vaadin.event.ShortcutListener;
 import com.vaadin.server.ClassResource;
 import com.vaadin.server.ThemeResource;
-import com.vaadin.shared.ui.MarginInfo;
-import com.vaadin.shared.ui.label.ContentMode;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.*;
 import com.vaadin.ui.Button.ClickListener;
@@ -78,7 +76,7 @@ public class QueryPanel extends GridLayout implements TextChangeListener,
   private PopupButton btHistory;
   private ListSelect lstHistory;
   private QueryController controller;
-  private ProgressBar piCount;
+  public ProgressBar piCount;
   private String lastPublicStatus;
   private List<HistoryEntry> history;
   private Window historyWindow;
@@ -251,6 +249,7 @@ public class QueryPanel extends GridLayout implements TextChangeListener,
      * MOR: "More actions" button 
      * HIST: "History" button
      * STAT: Text field with the real status
+     * PROG: indefinite progress bar (spinning circle)
      * 
      *   \  0  |  1  |  2  |  3  
      * --+-----+---+---+---+-----
@@ -260,7 +259,7 @@ public class QueryPanel extends GridLayout implements TextChangeListener,
      * --+-----+-----+-----+-----
      * 2 | SEA | MOR | HIST|     
      * --+-----+-----+-----+-----
-     * 3 | STAT| STAT| STAT| STAT
+     * 3 | STAT| STAT| STAT| PROG
      */
     addComponent(txtQuery, 0, 0, 2, 1);
     addComponent(txtStatus, 0, 3, 2, 3);
@@ -462,14 +461,6 @@ public class QueryPanel extends GridLayout implements TextChangeListener,
           piCount.setEnabled(true);
         }
       }
-      else
-      {
-        if(piCount.isVisible())
-        {
-          piCount.setVisible(false);
-          piCount.setEnabled(false);
-        }
-      }
       
       btShowResult.setEnabled(!enabled);
 //      btShowResultNewTab.setEnabled(!enabled);
@@ -487,6 +478,18 @@ public class QueryPanel extends GridLayout implements TextChangeListener,
     }
   }
 
+    public void setStatus(String status, String resultStatus)
+  {
+    if(txtStatus != null)
+    {
+      txtStatus.setReadOnly(false);
+      txtStatus.setValue(status + resultStatus);
+      lastPublicStatus = status;
+      txtStatus.setReadOnly(true);
+    }
+  }
+
+  
   private static class ShowKeyboardClickListener implements ClickListener
   {
 
@@ -621,9 +624,9 @@ public class QueryPanel extends GridLayout implements TextChangeListener,
     
   }
 
-  public String getTxtStatusValue()
+  public String getLastPublicStatus()
   {
-    return txtStatus.getValue();
+    return lastPublicStatus;
   }
 
   public QueryController getQueryController()

--- a/annis-gui/src/main/java/annis/gui/resultview/ResultViewPanel.java
+++ b/annis-gui/src/main/java/annis/gui/resultview/ResultViewPanel.java
@@ -39,7 +39,6 @@ import com.vaadin.ui.MenuBar;
 import com.vaadin.ui.MenuBar.MenuItem;
 import com.vaadin.ui.Notification;
 import com.vaadin.ui.Panel;
-import com.vaadin.ui.ProgressBar;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.themes.ChameleonTheme;
@@ -225,7 +224,7 @@ public class ResultViewPanel extends VerticalLayout implements
     this.projectQueue = queue;
     this.currentQuery = q;
     this.numberOfResults = numberOfResults;
-    strCurrentCaption =  sui.getControlPanel().getQueryPanel().getTxtStatusValue();
+    strCurrentCaption =  sui.getControlPanel().getQueryPanel().getLastPublicStatus();
     
     paging.setPageSize(q.getLimit(), false);
     paging.setInfo(q.getQuery());
@@ -294,7 +293,7 @@ public class ResultViewPanel extends VerticalLayout implements
           currentResults += newPanels.size();
 
           String strResults  = numberOfResults > 1 ? "results" : "result";
-          sui.getControlPanel().getQueryPanel().setStatus(strCurrentCaption + " (showing " + currentResults + "/" + numberOfResults + " " + strResults + ")");          
+          sui.getControlPanel().getQueryPanel().setStatus(sui.getControlPanel().getQueryPanel().getLastPublicStatus(), " (showing " + currentResults + "/" + numberOfResults + " " + strResults + ")");          
 
           if (currentResults == numberOfResults)
           {
@@ -332,7 +331,15 @@ public class ResultViewPanel extends VerticalLayout implements
 
   public void showFinishedSubgraphSearch()
   {
-
+    //Search complete, stop progress bar control
+    if (sui.getControlPanel().getQueryPanel().piCount != null )
+    {
+      if (sui.getControlPanel().getQueryPanel().piCount.isVisible())
+       {
+           sui.getControlPanel().getQueryPanel().piCount.setVisible(false);
+           sui.getControlPanel().getQueryPanel().piCount.setEnabled(false);
+       }
+     }
   }
 
   private List<SingleResultPanel> createPanels(SaltProject p, int offset)


### PR DESCRIPTION
Removed progressbar because it made results jump up when it disappeared. Moved progress information to query panel as a status message.
