### PR TITLE
Embedding visualizations in external web pages - issue#226(1b)

### DIFF
--- a/annis-gui/src/main/java/annis/gui/SearchUI.java
+++ b/annis-gui/src/main/java/annis/gui/SearchUI.java
@@ -950,6 +950,10 @@ public class SearchUI extends AnnisBaseUI
   
    private void evaluateFragmentVis(String fragment)
   {
+    ////example local testing query url
+    ////corpus=shenoute.a22, vis=htmldoc, doc=YA421-428, sty=“config:dipl"
+    //http://localhost:8084/annis-gui/#_c=c2hlbm91dGUuYTIy&vis=htmldoc&_doc=WUE0MjEtNDI4&_sty=ZGlwbA==
+
     // do nothing if not changed
     if (fragment == null || fragment.isEmpty() || fragment.equals(
       lastQueriedFragment))
@@ -968,6 +972,7 @@ public class SearchUI extends AnnisBaseUI
       corpora = getMappedCorpora(Arrays.asList(originalCorpusNames));
     }
     
+    //get other parameters: -visualizer(htmldoc),-document name(doc),-style(sty) 
     if (args.get("vis") != null && args.get("doc") != null && args.get("sty") != null)
     {
       String vis = args.get("vis");
@@ -975,8 +980,6 @@ public class SearchUI extends AnnisBaseUI
       String sty = args.get("sty");
       
       
-    
-    //get other parameters: -visualizer(htmldoc),-document name(11299),-style(infstr) //both config and css
     
     new Notification("HTML visualizer", 
       "<div><h2>HTML document visualizer parameters:</h2>"
@@ -987,9 +990,7 @@ public class SearchUI extends AnnisBaseUI
       + "</div>",
       Notification.Type.WARNING_MESSAGE, true).show(Page.getCurrent());
       
-    //we already have this in the current class searchUI:    
-    //docBrowserController = new DocBrowserController(this);
-
+   
     // get input parameters
     HTMLVis visualizer;
     visualizer = new HTMLVis();
@@ -1001,28 +1002,15 @@ public class SearchUI extends AnnisBaseUI
     config.setMappings("config:" + sty);
     config.setNamespace(null);
     config.setType(vis);
-    
-    
+        
     String corpus = args.get("c");
-    
-    //input = createInput(corpus, doc, config, visualizer.isUsingRawText(), nodeAnnoFilter);
+    //create input    
     input = docBrowserController.createInput(corpus, doc, config, false, null);
-    VisualizationDefinition[] definitions = visualizer.parseDefinitions(corpus, input.getMappings());
-
-
-    //display document in notification, works:
-    String htmlcode;
-    htmlcode = visualizer.createHTML(input.getSResult().getSDocumentGraph(),definitions);
-    //new Notification("HTML visualizer", htmlcode,Notification.Type.WARNING_MESSAGE, true).show(Page.getCurrent());
-    
-    
-    Label lblResult = new Label(htmlcode, ContentMode.HTML);
-    //using label
-    Panel panel = new Panel(lblResult);
-    panel.setWidth("700px");
+    //create components, put in a panel
+    Panel viszr = visualizer.createComponent(input, null);
     
     // Set the panel as the content of the UI
-    setContent(panel);
+    setContent(viszr);
    
     
     

--- a/annis-gui/src/main/java/annis/gui/SearchUI.java
+++ b/annis-gui/src/main/java/annis/gui/SearchUI.java
@@ -978,13 +978,6 @@ public class SearchUI extends AnnisBaseUI
     
     //get other parameters: -visualizer(htmldoc),-document name(11299),-style(infstr) //both config and css
     
-    //example html doc url:-visualizer(html), v=aHRtbA== ,-document name(11299), d=MTEyOTkNCg==,-style(infstr) //both config and css, s=aW5mc3Ry
-
-    //hence: #_c=cGNjMg==&v=aHRtbA==&doc=MTEyOTkNCg==&sty=aW5mc3Ry
-    
-    
-    //notification: new Notification("hello zangsir", "how are you", Notification.Type.WARNING_MESSAGE, true).show(Page.getCurrent());
-    
     new Notification("HTML visualizer", 
       "<div><h2>HTML document visualizer parameters:</h2>"
       + "<ul><li>corpus: " + corpora + "</li>"
@@ -1010,48 +1003,27 @@ public class SearchUI extends AnnisBaseUI
     config.setType(vis);
     
     
-    
     String corpus = args.get("c");
     
     //input = createInput(corpus, doc, config, visualizer.isUsingRawText(), nodeAnnoFilter);
     input = docBrowserController.createInput(corpus, doc, config, false, null);
     VisualizationDefinition[] definitions = visualizer.parseDefinitions(corpus, input.getMappings());
 
-    //createComponent: doesn't work, 
-    //Component vislz;
-    //vislz = visualizer.createComponent(input, null);
+
     //display document in notification, works:
     String htmlcode;
     htmlcode = visualizer.createHTML(input.getSResult().getSDocumentGraph(),definitions);
-    new Notification("HTML visualizer", htmlcode,Notification.Type.WARNING_MESSAGE, true).show(Page.getCurrent());
+    //new Notification("HTML visualizer", htmlcode,Notification.Type.WARNING_MESSAGE, true).show(Page.getCurrent());
     
-
-
-    //panel.setContent(
-    //new Label("This is a Label inside a Panel. There is " +
-             // "enough text in the label to make the text " +
-              //"wrap when it exceeds the width of the panel."));
     
     Label lblResult = new Label(htmlcode, ContentMode.HTML);
     //using label
     Panel panel = new Panel(lblResult);
     panel.setWidth("700px");
     
-    //VerticalLayout panelContent = new VerticalLayout();
-    //panel.setContent(panelContent);
-
-
     // Set the panel as the content of the UI
     setContent(panel);
-    
-    
-    //lblResult.setSizeUndefined();
-    //lblResult.setValue(visualizer.createHTML(input.getSResult().getSDocumentGraph(), definitions));
-    //panel.setContent(lblResult);
-    //VerticalLayout wLayout = new VerticalLayout();
-    //setContent(wLayout);
-    //wLayout.setSizeFull();
-    //wLayout.addComponent(lblResult);
+   
     
     
     

--- a/annis-gui/src/main/java/annis/gui/docbrowser/DocBrowserController.java
+++ b/annis-gui/src/main/java/annis/gui/docbrowser/DocBrowserController.java
@@ -170,7 +170,7 @@ public class DocBrowserController implements Serializable
    * @return a {@link VisualizerInput} input, which is usable for rendering the
    * whole document.
    */
-  private VisualizerInput createInput(String corpus, String docName,
+  public VisualizerInput createInput(String corpus, String docName,
     Visualizer config, boolean isUsingRawText, List<String> nodeAnnoFilter)
   {
     VisualizerInput input = new VisualizerInput();

--- a/annis-visualizers/src/main/java/annis/visualizers/htmlvis/HTMLVis.java
+++ b/annis-visualizers/src/main/java/annis/visualizers/htmlvis/HTMLVis.java
@@ -221,7 +221,7 @@ public class HTMLVis extends AbstractVisualizer<Panel>
     }
   }
   
-  private VisualizationDefinition[] parseDefinitions(String toplevelCorpusName,
+  public VisualizationDefinition[] parseDefinitions(String toplevelCorpusName,
     Properties mappings)
   {
     InputStream inStreamConfigRaw = null;
@@ -275,7 +275,7 @@ public class HTMLVis extends AbstractVisualizer<Panel>
   
   
 
-  private String createHTML(SDocumentGraph graph,
+  public String createHTML(SDocumentGraph graph,
     VisualizationDefinition[] definitions)
   {
     SortedMap<Long, SortedSet<OutputItem>> outputStartTags


### PR DESCRIPTION
[issue#226, 1b] A new method (evaluateFragmentVis() ) is created in SearchUI class for parsing URL call parameters and displaying the htmldoc visualization view of a requested document in the corpus. This functionality is realized by first parsing the url query parameters of corpus name(c), visualizer (vis=htmldoc), stylesheet name(sty), document name(doc) (e.g., #c=shenoute.a22, vis=htmldoc, doc=YA421-428, sty=dipl, in base64), and directly calling the HTMLVis.createComponent() method. This creates and returns a Panel and the resulting panel containing the htmldoc visualization of requested document is then displayed (css style is correctly applied). Meanwhile a notification is given showing the parameter values (corpus, document, visualization, stylesheets) of the url call. The result should be exactly the same as clicking the document visualization in DocBrowser. 