### PR TITLE
Added systemd unit file for ANNIS service.

### DIFF
--- a/buildbot_scripts/annis.service
+++ b/buildbot_scripts/annis.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=ANNIS Corpus Visualizer
+After=syslog.target
+
+[Service]
+Type=forking
+Environment=ANNIS_HOME=/opt/annis
+ExecStart=/bin/sh /opt/annis/bin/annis-service.sh start
+ExecStop=/bin/sh /opt/annis/bin/annis-service.sh stop
+StandardOutput=null
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
systemd is a replacement for SysV init that has become standard in most major distributions.

The unit file assumes installation to /opt/annis.