### PR TITLE
Moved help messages of exporters into the exporter classes themselves.

### DIFF
--- a/annis-gui/src/main/java/annis/gui/ExportPanel.java
+++ b/annis-gui/src/main/java/annis/gui/ExportPanel.java
@@ -212,47 +212,10 @@ public class ExportPanel extends FormLayout
 
   private void initHelpMessages()
   {
-    help4Exporter.put(SearchUI.EXPORTER[0].getClass().getSimpleName(),
-      "The WEKA Exporter exports only the "
-      + "values of the elements searched for by the user, ignoring the context "
-      + "around search results. The values for all annotations of each of the "
-      + "found nodes is given in a comma-separated table (CSV). At the top of "
-      + "the export, the names of the columns are given in order according to "
-      + "the WEKA format.<br/><br/>"
-      + "Parameters: <br/>"
-      + "<em>metakeys</em> - comma seperated list of all meta data to include in the result (e.g. "
-      + "<code>metakeys=title,documentname</code>)");
-
-    help4Exporter.put(SearchUI.EXPORTER[1].getClass().getSimpleName(),
-      "The CSV Exporter exports only the "
-      + "values of the elements searched for by the user, ignoring the context "
-      + "around search results. The values for all annotations of each of the "
-      + "found nodes is given in a comma-separated table (CSV). <br/><br/>"
-      + "Parameters: <br/>"
-      + "<em>metakeys</em> - comma seperated list of all meta data to include in the result (e.g. "
-      + "<code>metakeys=title,documentname</code>)");
-
-    help4Exporter.put(SearchUI.EXPORTER[2].getClass().getSimpleName(),
-      "The Text Exporter exports the token covered by the matched nodes of every search result and "
-      + "its context, one line per result. Beside the text of the token it also contains all token annotations separated by \"/\".");
-
-    help4Exporter.put(SearchUI.EXPORTER[3].getClass().getSimpleName(),
-      "The Grid Exporter can export all annotations of a search result and its "
-      + "context. Each annotation layer is represented in a separate line, and the "
-      + "tokens covered by each annotation are given as number ranges after each "
-      + "annotation in brackets. To suppress token numbers, input numbers=false "
-      + "into the parameters box below. To display only a subset of annotations "
-      + "in any order use the \"Annotation keys\" text field, input e.g. \"tok,pos,cat\" "
-      + "to show tokens and the "
-      + "annotations pos and cat.<br /><br />"
-      + "Parameters: <br/>"
-      + "<em>metakeys</em> - comma seperated list of all meta data to include in the result (e.g. "
-      + "<code>metakeys=title,documentname</code>) <br />"
-      + "<em>numbers</em> - set to \"false\" if the grid event numbers should not be included in the output (e.g. "
-      + "<code>numbers=false</code>)");
-    
-    help4Exporter.put(SearchUI.EXPORTER[4].getClass().getSimpleName(),
-      "The SimpleTextExporter exports only the plain text of every search result. ");
+	for (Exporter exp : SearchUI.EXPORTER)
+	{
+	  help4Exporter.put(exp.getClass().getSimpleName(), exp.getHelpMessage());
+	}
   }
 
   public class ExporterSelectionHelpListener implements

--- a/annis-gui/src/main/java/annis/gui/SearchUI.java
+++ b/annis-gui/src/main/java/annis/gui/SearchUI.java
@@ -25,6 +25,7 @@ import annis.gui.exporter.CSVExporter;
 import annis.gui.exporter.Exporter;
 import annis.gui.exporter.GridExporter;
 import annis.gui.exporter.SimpleTextExporter;
+import annis.gui.exporter.OrfeoExporter;
 import annis.gui.exporter.TextExporter;
 import annis.gui.exporter.WekaExporter;
 import annis.libgui.media.MediaController;
@@ -101,6 +102,7 @@ public class SearchUI extends CommonUI
   
   static final Exporter[] EXPORTER = new Exporter[]
   {
+    new OrfeoExporter(),
     new WekaExporter(),
     new CSVExporter(),
     new TextExporter(),

--- a/annis-gui/src/main/java/annis/gui/exporter/CSVExporter.java
+++ b/annis-gui/src/main/java/annis/gui/exporter/CSVExporter.java
@@ -90,6 +90,16 @@ public class CSVExporter implements Exporter, Serializable
   {
     return false;
   }
-  
-  
+
+  @Override
+  public String getHelpMessage()
+  {
+	return "The CSV Exporter exports only the "
+			+ "values of the elements searched for by the user, ignoring the context "
+			+ "around search results. The values for all annotations of each of the "
+			+ "found nodes is given in a comma-separated table (CSV). <br/><br/>"
+			+ "Parameters: <br/>"
+			+ "<em>metakeys</em> - comma seperated list of all meta data to include in the result (e.g. "
+			+ "<code>metakeys=title,documentname</code>)";
+  }
 }

--- a/annis-gui/src/main/java/annis/gui/exporter/Exporter.java
+++ b/annis-gui/src/main/java/annis/gui/exporter/Exporter.java
@@ -33,4 +33,5 @@ public interface Exporter
   
   public boolean isCancelable();
   
+  public String getHelpMessage();
 }

--- a/annis-gui/src/main/java/annis/gui/exporter/GridExporter.java
+++ b/annis-gui/src/main/java/annis/gui/exporter/GridExporter.java
@@ -136,8 +136,24 @@ public class GridExporter extends GeneralTextExporter
       out.append("\n\n");
     }
   }
-  
-  
+
+  @Override
+  public String getHelpMessage()
+  {
+	return "The Grid Exporter can export all annotations of a search result and its "
+			+ "context. Each annotation layer is represented in a separate line, and the "
+			+ "tokens covered by each annotation are given as number ranges after each "
+			+ "annotation in brackets. To suppress token numbers, input numbers=false "
+			+ "into the parameters box below. To display only a subset of annotations "
+			+ "in any order use the \"Annotation keys\" text field, input e.g. \"tok,pos,cat\" "
+			+ "to show tokens and the "
+			+ "annotations pos and cat.<br /><br />"
+			+ "Parameters: <br/>"
+			+ "<em>metakeys</em> - comma seperated list of all meta data to include in the result (e.g. "
+			+ "<code>metakeys=title,documentname</code>) <br />"
+			+ "<em>numbers</em> - set to \"false\" if the grid event numbers should not be included in the output (e.g. "
+			+ "<code>numbers=false</code>)";
+  }
 
   @Override
   public SubgraphFilter getSubgraphFilter()

--- a/annis-gui/src/main/java/annis/gui/exporter/OrfeoExporter.java
+++ b/annis-gui/src/main/java/annis/gui/exporter/OrfeoExporter.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2009-2011 Collaborative Research Centre SFB 632 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package annis.gui.exporter;
+
+import annis.model.AnnisNode;
+import annis.model.Annotation;
+import annis.service.ifaces.AnnisResult;
+import annis.service.ifaces.AnnisResultSet;
+import annis.service.objects.SubgraphFilter;
+import com.google.common.base.Splitter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class OrfeoExporter extends GeneralTextExporter
+{
+
+  @Override
+  public void convertText(AnnisResultSet queryResult, List<String> keys, 
+    Map<String,String> args, Writer out, int offset) throws IOException
+  {
+    
+    Map<String, Map<String, Annotation>> metadataCache = 
+      new HashMap<>();
+
+
+    boolean showNumbers = true;
+    if (args.containsKey("numbers"))
+    {
+      String arg = args.get("numbers");
+      if (arg.equalsIgnoreCase("false")
+        || arg.equalsIgnoreCase("0")
+        || arg.equalsIgnoreCase("off"))
+      {
+        showNumbers = false;
+      }
+    }
+    List<String> metaKeys = new LinkedList<>();
+    if(args.containsKey("metakeys"))
+    {
+      Iterable<String> it = 
+        Splitter.on(",").trimResults().split(args.get("metakeys"));
+      for(String s : it)
+      {
+        metaKeys.add(s);
+      }
+    }
+
+	String speakerChange = args.containsKey("c") ? args.get("c") : null;
+
+    int counter = 0;
+    for (AnnisResult annisResult : queryResult)
+    {
+      HashMap<String, TreeMap<Long, Span>> annos =
+        new HashMap<>();
+
+      counter++;
+      out.append((counter + offset) + ". \t");
+
+	  List<AnnisNode> tokenList = annisResult.getGraph().getTokens();
+	  long tokenOffset = tokenList.get(0).getTokenIndex() - 1;
+	  for (int i = annisResult.getPath().length - 1; i >= 0; i--)
+	  {
+		out.append(annisResult.getPath()[i]);
+		if (i > 0)
+		  out.append(" > ");
+	  }
+	  long lastTokenIndex = tokenList.get(tokenList.size() - 1).getTokenIndex();
+	  out.append(" (tokens ").append((tokenOffset + 2) + "-" + (lastTokenIndex + 1)).append(")\n");
+
+	  for (AnnisNode resolveNode : annisResult.getGraph().getNodes())
+	  {
+        for (Annotation resolveAnnotation : resolveNode.getNodeAnnotations())
+        {
+          String k = resolveAnnotation.getName();
+          if (annos.get(k) == null)
+          {
+            annos.put(k, new TreeMap<Long, Span>());
+          }
+
+          // create a separate span for every annotation
+          annos.get(k).put(resolveNode.getLeftToken(), new Span(resolveNode.getLeftToken(), resolveNode.getRightToken(),
+            resolveAnnotation.getValue()));
+          
+        }
+      }
+
+      for (String k : keys)
+      {
+
+        if ("tok".equals(k))
+        {
+          out.append("\t" + k + "\t ");
+		  if (annos.get("speaker") != null && speakerChange != null) {
+			String prev = null;
+			Iterator<Span> it = annos.get("speaker").values().iterator();
+			for (AnnisNode annisNode : annisResult.getGraph().getTokens()) {
+			  String speaker = it.next().getValue();
+			  if (prev == null)
+			  {
+				prev = speaker;
+			  }
+			  else if (!prev.equals(speaker))
+			  {
+				out.append(speakerChange+" ");
+				prev = speaker;
+			  }
+			  out.append(annisNode.getSpannedText() + " ");
+			}
+		  }
+		  else
+		  {
+			for (AnnisNode annisNode : annisResult.getGraph().getTokens())
+			{
+			  out.append(annisNode.getSpannedText() + " ");
+			}
+		  }
+		  out.append("\n");
+		}
+        else if ("pos".equalsIgnoreCase(k) || "lemma".equalsIgnoreCase(k))
+        {
+          if(annos.get(k) != null)
+          {
+            out.append("\t" + k + "\t ");
+            for(Span s : annos.get(k).values())
+            {
+
+              out.append(s.getValue());
+
+              if (showNumbers)
+              {
+                long leftIndex = Math.max(1, s.getStart() - tokenOffset);
+                long rightIndex = s.getEnd() - tokenOffset;
+                out.append("[" + leftIndex
+                  + "-" + rightIndex + "]");
+              }
+              out.append(" ");
+
+            }
+            out.append("\n");
+          }
+        }
+      }
+      
+      if(!metaKeys.isEmpty())
+      {
+        String[] path = annisResult.getPath();
+        super.appendMetaData(out, metaKeys, path[path.length-1], annisResult.getDocumentName(), metadataCache);
+      }
+      out.append("\n\n");
+    }
+  }
+
+  @Override
+  public String getHelpMessage() {
+	return "The Orfeo exporter is a modification of GridExporter with a few differences:<br/><br/>"
+			+ "The path of the sample and the indices of the tokens in the context are included.<br/>"
+			+ "Annotation layers other than POS and lemma are omitted.<br/>"
+			+ "If speaker annotation is available (layer <em>speaker</em>) and the parameter <em>c</em>"
+			+ " is defined, then the string in that parameter is used within the token list"
+			+ " to indicate speaker changes.";
+  }
+
+  @Override
+  public SubgraphFilter getSubgraphFilter()
+  {
+    return SubgraphFilter.all;
+  }
+  
+  
+
+
+  private static class Span
+  {
+
+    private long start;
+    private long end;
+    private String value;
+
+    public Span(long start, long end, String value)
+    {
+      this.start = start;
+      this.end = end;
+      this.value = value;
+    }
+
+    public long getStart()
+    {
+      return start;
+    }
+
+    public void setStart(long start)
+    {
+      this.start = start;
+    }
+
+    public long getEnd()
+    {
+      return end;
+    }
+
+    public void setEnd(long end)
+    {
+      this.end = end;
+    }
+
+    public String getValue()
+    {
+      return value;
+    }
+
+    public void setValue(String value)
+    {
+      this.value = value;
+    }
+  }
+}

--- a/annis-gui/src/main/java/annis/gui/exporter/SimpleTextExporter.java
+++ b/annis-gui/src/main/java/annis/gui/exporter/SimpleTextExporter.java
@@ -29,5 +29,10 @@ public class SimpleTextExporter extends GeneralTextExporter
   {
     return SubgraphFilter.token;
   }
-  
+
+  @Override
+  public String getHelpMessage()
+  {
+	return "The SimpleTextExporter exports only the plain text of every search result. ";
+  }
 }

--- a/annis-gui/src/main/java/annis/gui/exporter/TextExporter.java
+++ b/annis-gui/src/main/java/annis/gui/exporter/TextExporter.java
@@ -96,13 +96,13 @@ public class TextExporter extends GeneralTextExporter
     }
   }
 
-  
-  
-  
-  
-  
-  
-  
+  @Override
+  public String getHelpMessage()
+  {
+	return "The Text Exporter exports the token covered by the matched nodes of every search result and "
+			+ "its context, one line per result. Beside the text of the token it also contains all token annotations separated by \"/\".";
+  }
+
   @Override
   public SubgraphFilter getSubgraphFilter()
   {

--- a/annis-gui/src/main/java/annis/gui/exporter/WekaExporter.java
+++ b/annis-gui/src/main/java/annis/gui/exporter/WekaExporter.java
@@ -85,6 +85,20 @@ public class WekaExporter implements Exporter, Serializable
   }
 
   @Override
+  public String getHelpMessage()
+  {
+	return "The WEKA Exporter exports only the "
+			+ "values of the elements searched for by the user, ignoring the context "
+			+ "around search results. The values for all annotations of each of the "
+			+ "found nodes is given in a comma-separated table (CSV). At the top of "
+			+ "the export, the names of the columns are given in order according to "
+			+ "the WEKA format.<br/><br/>"
+			+ "Parameters: <br/>"
+			+ "<em>metakeys</em> - comma seperated list of all meta data to include in the result (e.g. "
+			+ "<code>metakeys=title,documentname</code>)";
+  }
+
+  @Override
   public boolean isCancelable()
   {
     return false;


### PR DESCRIPTION
The help messages for the exporter classes are defined in the `ExportPanel` class. Adding a new exporter or just simply changing the order of the exporters will break the help messages if they are not also changed, which is easy to forget. I added a `getHelpMessage` method to the `Exporter` interface. Now adding or reordering importers does not require changes to `ExportPanel` anymore.