### PR TITLE
Corrected reference to old pcc2 query in German. 

### DIFF
--- a/annis-gui/src/main/webapp/VAADIN/tutorial/index.html
+++ b/annis-gui/src/main/webapp/VAADIN/tutorial/index.html
@@ -419,13 +419,7 @@ The pointing relation operator can also search for longer chains of coreference,
       </div>
 
       <p>
-        This query searches for a present tense lexical verb (with the part-of-speech VVZ or VVP)
-        and a token, with a pointing relation of the type 'dep' (for
-        dependency) between the two, annotated with 'func="dobj"' (the
-        function 'direct object'). The result can be viewed with the
-        arch dependency visualizer, which shows the verb gibt 'gives' and its
-        object Wunder 'miracles'.
-      </p>
+This query searches for a present tense lexical verb (with the part-of-speech VVZ or VVP) and a token, with a pointing relation of the type 'dep' (for dependency) between the two, annotated with 'func="dobj"' (the function 'direct object'). The result can be viewed with the arch dependency visualizer, which shows the verb 'shows' and its object 'location'.      </p>
 
       <img src="dep_vis.png" width="350">
 


### PR DESCRIPTION
Updated to equivalent GUM query.