### PR TITLE
Display command to create new database in one line

### DIFF
--- a/doc/src/doxygen/admin/install.md
+++ b/doc/src/doxygen/admin/install.md
@@ -40,8 +40,7 @@ export PATH=$PATH:$ANNIS_HOME/bin
 6. Next **initialize** your ANNIS database (only the first time you use the system).
 When the ANNIS service is normally installed, it assumes it can get PostgreSQL super user rights for this step. Thus you need the superuser password.
 \code{.sh}
-annis-admin.sh init -u <username> -d <dbname> --schema <schema> -p <new user password>
--P <postgres superuser password>
+annis-admin.sh init -u <username> -d <dbname> --schema <schema> -p <new user password> -P <postgres superuser password>
 \endcode
 This call will 
 <ul><li>create a new database with the name given by the "-d" parameter</li>


### PR DESCRIPTION
- There is a linebreak before `-P <postgres superuser password>` which - when overlooked by the user - will result in the command not working when the user enters the first line separately from the second line. Pulling both together in one line solves this.