### PR TITLE
Set mnemonic on "overwrite" checkbox in ImportDialog to "w"

### DIFF
--- a/annis-kickstarter/src/main/java/de/hu_berlin/german/korpling/annis/kickstarter/ImportDialog.java
+++ b/annis-kickstarter/src/main/java/de/hu_berlin/german/korpling/annis/kickstarter/ImportDialog.java
@@ -473,6 +473,7 @@ public class ImportDialog extends javax.swing.JDialog
     lblCurrentCorpus.setText("Please select corpus for import!");
 
     jCheckBox1.setText("overwrite");
+    jCheckBox1.setMnemonic('w');
     jCheckBox1.addActionListener(new java.awt.event.ActionListener()
     {
       public void actionPerformed(java.awt.event.ActionEvent evt)


### PR DESCRIPTION
Makes importing corpora in the Kickstarter quicker for people who like to use the keyboard extensively.