### PR TITLE
Fix initial corpus set selection when pre-selected corpus is not visible 

### DIFF
--- a/annis-gui/src/main/java/annis/gui/QueryController.java
+++ b/annis-gui/src/main/java/annis/gui/QueryController.java
@@ -126,15 +126,6 @@ public class QueryController implements Serializable
       }
     });
     
-    this.state.getSelectedCorpora().addValueChangeListener(new Property.ValueChangeListener()
-    {
-
-      @Override
-      public void valueChange(Property.ValueChangeEvent event)
-      {
-        // TODO: check if the corpus is actually available to the user
-      }
-    });
   }
 
   public void validateQuery()

--- a/annis-gui/src/main/java/annis/gui/controlpanel/CorpusListPanel.java
+++ b/annis-gui/src/main/java/annis/gui/controlpanel/CorpusListPanel.java
@@ -903,6 +903,15 @@ public class CorpusListPanel extends VerticalLayout implements
                   && instanceConfig.getDefaultCorpusSet().length() > 0)
                 {
                   cbSelection.select(instanceConfig.getDefaultCorpusSet());
+                  
+                  // make sure the selected corpus set does contain the corpus
+                  Set<String> corpora = ui.getQueryState().getSelectedCorpora().getValue();
+                  Set<String> visibleCorpora = new HashSet<>(ui.getQueryState().
+                    getAvailableCorpora().getItemIds());
+                  if (!visibleCorpora.containsAll(corpora))
+                  {
+                    cbSelection.select(ALL_CORPORA);
+                  }
                 }
                 else
                 {

--- a/annis-service/nbactions-Console.xml
+++ b/annis-service/nbactions-Console.xml
@@ -10,7 +10,7 @@
                 <goal>org.codehaus.mojo:exec-maven-plugin:1.2.1:exec</goal>
             </goals>
             <properties>
-                <exec.args>-Dannis.home=target/annis-service-${project.version}-distribution/annis-service-${project.version} -classpath %classpath annis.AnnisRunner</exec.args>
+                <exec.args>-Dannis.home=. -classpath %classpath annis.AnnisRunner</exec.args>
                 <exec.executable>java</exec.executable>
             </properties>
         </action>
@@ -24,7 +24,7 @@
                 <goal>org.codehaus.mojo:exec-maven-plugin:1.2.1:exec</goal>
             </goals>
             <properties>
-                <exec.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address} -Dannis.home=target/annis-service-${project.version}-distribution/annis-service-${project.version} -classpath %classpath annis.AnnisRunner</exec.args>
+                <exec.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address} -Dannis.home=. -classpath %classpath annis.AnnisRunner</exec.args>
                 <exec.executable>java</exec.executable>
                 <jpda.listen>true</jpda.listen>
             </properties>
@@ -39,7 +39,7 @@
                 <goal>org.codehaus.mojo:exec-maven-plugin:1.2.1:exec</goal>
             </goals>
             <properties>
-                <exec.args>-Dannis.home=target/annis-service-${project.version}-distribution/annis-service-${project.version} -classpath %classpath annis.AnnisRunner</exec.args>
+                <exec.args>-Dannis.home=. -classpath %classpath annis.AnnisRunner</exec.args>
                 <exec.executable>java</exec.executable>
             </properties>
         </action>

--- a/annis-service/nbactions-ServiceRun.xml
+++ b/annis-service/nbactions-ServiceRun.xml
@@ -10,7 +10,7 @@
                 <goal>org.codehaus.mojo:exec-maven-plugin:1.2.1:exec</goal>
             </goals>
             <properties>
-                <exec.args>-Xverify:none -Dannisservice.pid_file=annis.pid -Dannis.nosecurity=false -Dannis.home=target/annis-service-${project.version}-distribution/annis-service-${project.version} -classpath %classpath annis.service.internal.AnnisServiceRunner</exec.args>
+                <exec.args>-Xverify:none -Dannisservice.pid_file=annis.pid -Dannis.nosecurity=false -Dannis.home=. -classpath %classpath annis.service.internal.AnnisServiceRunner</exec.args>
                 <exec.executable>java</exec.executable>
                 <skipTests>true</skipTests>
             </properties>
@@ -25,7 +25,7 @@
                 <goal>org.codehaus.mojo:exec-maven-plugin:1.2.1:exec</goal>
             </goals>
             <properties>
-                <exec.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address} -Xverify:none -Dannisservice.pid_file=annis.pid -Dannis.nosecurity=false -Dannis.home=target/annis-service-${project.version}-distribution/annis-service-${project.version} -classpath %classpath annis.service.internal.AnnisServiceRunner</exec.args>
+                <exec.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address} -Xverify:none -Dannisservice.pid_file=annis.pid -Dannis.nosecurity=false -Dannis.home=. -classpath %classpath annis.service.internal.AnnisServiceRunner</exec.args>
                 <exec.executable>java</exec.executable>
                 <jpda.listen>true</jpda.listen>
             </properties>
@@ -40,7 +40,7 @@
                 <goal>org.codehaus.mojo:exec-maven-plugin:1.2.1:exec</goal>
             </goals>
             <properties>
-                <exec.args>-Xverify:none -Dannisservice.pid_file=annis.pid -Dannis.nosecurity=false -Dannis.home=target/annis-service-${project.version}-distribution/annis-service-${project.version} -classpath %classpath annis.service.internal.AnnisServiceRunner</exec.args>
+                <exec.args>-Xverify:none -Dannisservice.pid_file=annis.pid -Dannis.nosecurity=false -Dannis.home=. -classpath %classpath annis.service.internal.AnnisServiceRunner</exec.args>
                 <exec.executable>java</exec.executable>
             </properties>
         </action>


### PR DESCRIPTION
In case a pre-selected corpus (like selected using the a reference link) the instance default corpus set is always loaded, even when the selected corpus is not part of the corpus set. This pull request fixes this behavior.