### PR TITLE
Add benchmark modes to perform different kind of benchmarks

### DIFF
--- a/annis-service/nb-configuration.xml
+++ b/annis-service/nb-configuration.xml
@@ -22,5 +22,26 @@ That way multiple projects can share the same settings (useful for formatting ru
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
         <org-netbeans-modules-javascript2-requirejs.enabled>true</org-netbeans-modules-javascript2-requirejs.enabled>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.indent-shift-width>2</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.indent-shift-width>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.placeWhileOnNewLine>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.placeWhileOnNewLine>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.placeFinallyOnNewLine>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.placeFinallyOnNewLine>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.classDeclBracePlacement>NEW_LINE</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.classDeclBracePlacement>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.continuationIndentSize>2</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.continuationIndentSize>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-line-wrap>words</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-line-wrap>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.placeElseOnNewLine>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.placeElseOnNewLine>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.otherBracePlacement>NEW_LINE</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.otherBracePlacement>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.spaces-per-tab>2</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.spaces-per-tab>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.placeCatchOnNewLine>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.placeCatchOnNewLine>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.tab-size>2</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.tab-size>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-limit-width>80</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-limit-width>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.methodDeclBracePlacement>NEW_LINE</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.methodDeclBracePlacement>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.expand-tabs>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.expand-tabs>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.text-line-wrap>words</org-netbeans-modules-editor-indent.CodeStyle.project.text-line-wrap>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>2</org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>2</org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>2</org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>80</org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>true</org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>
+        <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project</org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
     </properties>
 </project-shared-configuration>

--- a/annis-service/src/main/java/annis/AnnisRunner.java
+++ b/annis-service/src/main/java/annis/AnnisRunner.java
@@ -125,11 +125,11 @@ public class AnnisRunner extends AnnisBaseRunner
   
   public enum BenchmarkMode 
   {
-    sequential_random,
-    warmup_random
+    warmup_random,
+    sequential_random
   }
   
-  private BenchmarkMode benchMode;
+  private BenchmarkMode benchMode = BenchmarkMode.warmup_random;
 
   private MetaDataFilter metaDataFilter;
 

--- a/annis-service/src/main/java/annis/AnnisRunner.java
+++ b/annis-service/src/main/java/annis/AnnisRunner.java
@@ -40,6 +40,7 @@ import annis.sqlgen.extensions.AnnotateQueryData;
 import annis.sqlgen.extensions.LimitOffsetQueryData;
 import annis.utils.Utils;
 import au.com.bytecode.opencsv.CSVWriter;
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.io.Files;
 import java.io.BufferedReader;
@@ -121,6 +122,14 @@ public class AnnisRunner extends AnnisBaseRunner
   private List<Long> corpusList;
 
   private boolean clearCaches;
+  
+  public enum BenchmarkMode 
+  {
+    sequential_random,
+    warmup_random
+  }
+  
+  private BenchmarkMode benchMode;
 
   private MetaDataFilter metaDataFilter;
 
@@ -916,6 +925,24 @@ public class AnnisRunner extends AnnisBaseRunner
       else
       {
         clearCaches = Boolean.parseBoolean(value);
+      }
+    }
+    else if("bench-mode".equals(setting))
+    {
+      if(show)
+      {
+        value = benchMode.name();
+      }
+      else
+      {
+        try
+        {
+          benchMode = BenchmarkMode.valueOf(value);
+        }
+        catch(IllegalArgumentException ex)
+        {
+          out.println("Invalid value, allowed values are: " + Joiner.on(", ").join(BenchmarkMode.values()));
+        }
       }
     }
     else if ("corpus-list".equals(setting))

--- a/annis-service/src/main/java/annis/AnnisRunner.java
+++ b/annis-service/src/main/java/annis/AnnisRunner.java
@@ -73,7 +73,6 @@ import org.eclipse.emf.common.util.URI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 // TODO: test AnnisRunner
 public class AnnisRunner extends AnnisBaseRunner
 {
@@ -97,7 +96,7 @@ public class AnnisRunner extends AnnisBaseRunner
   private int context;
 
   private AnnisParserAntlr annisParser;
-  
+
   private int matchLimit;
 
   private QueriesGenerator queriesGenerator;
@@ -110,25 +109,25 @@ public class AnnisRunner extends AnnisBaseRunner
   private int left = 5;
 
   private int right = 5;
-  
+
   private OrderType order = OrderType.ascending;
 
   private String segmentationLayer = null;
-  
+
   private SubgraphFilter filter = SubgraphFilter.all;
-  
+
   private FrequencyTableQuery frequencyDef = null;
 
   private List<Long> corpusList;
 
   private boolean clearCaches;
-  
-  public enum BenchmarkMode 
+
+  public enum BenchmarkMode
   {
     warmup_random,
     sequential_random
   }
-  
+
   private BenchmarkMode benchMode = BenchmarkMode.warmup_random;
 
   private MetaDataFilter metaDataFilter;
@@ -196,7 +195,7 @@ public class AnnisRunner extends AnnisBaseRunner
     private int runs;
 
     private int errors;
-    
+
     private Integer count;
 
     private final List<Long> values = Collections.synchronizedList(
@@ -241,12 +240,12 @@ public class AnnisRunner extends AnnisBaseRunner
         "conf/spring/Shell.xml").getAbsolutePath();
       AnnisBaseRunner.getInstance("annisRunner", "file:" + path).run(args);
     }
-    catch(AnnisRunnerException ex)
+    catch (AnnisRunnerException ex)
     {
       log.error(ex.getMessage() + " (error code " + ex.getExitCode() + ")", ex);
       System.exit(ex.getExitCode());
     }
-    catch(Throwable ex)
+    catch (Throwable ex)
     {
       log.error(ex.getMessage(), ex);
       System.exit(1);
@@ -264,8 +263,8 @@ public class AnnisRunner extends AnnisBaseRunner
   {
     try
     {
-      
-      try(BufferedReader reader = new BufferedReader(new InputStreamReader(
+
+      try (BufferedReader reader = new BufferedReader(new InputStreamReader(
         new FileInputStream(filename), "UTF-8"));)
       {
         Map<String, Integer> queryRun = new HashMap<>();
@@ -402,7 +401,6 @@ public class AnnisRunner extends AnnisBaseRunner
     String annisQuery = getAnnisQueryFromFunctionCall(funcCall);
     QueryData queryData = analyzeQuery(annisQuery, doSqlFunctionName);
 
-
     out.println("NOTICE: left = " + left + "; right = " + right + "; limit = "
       + limit + "; offset = " + offset);
 
@@ -457,16 +455,15 @@ public class AnnisRunner extends AnnisBaseRunner
     {
       generator = getGraphSqlGenerator();
     }
-    else if("frequency".equals(function))
+    else if ("frequency".equals(function))
     {
       generator = frequencySqlGenerator;
     }
-    
+
     Validate.notNull(generator, "don't now query function: " + function);
 
     return generator;
   }
-  
 
   private String getAnnisQueryFromFunctionCall(String functionCall)
   {
@@ -482,7 +479,7 @@ public class AnnisRunner extends AnnisBaseRunner
     benchmarks.clear();
     benchmarkName = null;
   }
-  
+
   public void doBenchmarkName(String name)
   {
     this.benchmarkName = name;
@@ -515,11 +512,11 @@ public class AnnisRunner extends AnnisBaseRunner
         resetCaches(currentOS);
       }
 
-      SqlGeneratorAndExtractor<QueryData, ?> generator =
-        getGeneratorForQueryFunction(benchmark.functionCall);
+      SqlGeneratorAndExtractor<QueryData, ?> generator
+        = getGeneratorForQueryFunction(benchmark.functionCall);
       benchmark.sql = getGeneratorForQueryFunction(benchmark.functionCall).
         toSql(
-        benchmark.queryData);
+          benchmark.queryData);
       out.println("---> SQL query for: " + benchmark.functionCall);
       out.println(benchmark.sql);
       try
@@ -537,7 +534,7 @@ public class AnnisRunner extends AnnisBaseRunner
       out.println("---> running query sequentially " + SEQUENTIAL_RUNS
         + " times");
       String options = benchmarkOptions(benchmark.queryData);
-        
+
       for (int i = 0; i < SEQUENTIAL_RUNS; ++i)
       {
         if (i > 0)
@@ -555,17 +552,17 @@ public class AnnisRunner extends AnnisBaseRunner
           error = true;
         }
         long end = new Date().getTime();
-         long runtime = end - start;
-         
-        if(benchMode == BenchmarkMode.sequential_random)
+        long runtime = end - start;
+
+        if (benchMode == BenchmarkMode.sequential_random)
         {
           // record the runtime and other benchmark values when the sequental run is counted
           benchmark.sumTimeInMilliseconds += runtime;
           benchmark.values.add(runtime);
-          benchmark.bestTimeInMilliseconds =
-            Math.min(benchmark.bestTimeInMilliseconds, runtime);
-          benchmark.worstTimeInMilliseconds =
-            Math.max(benchmark.worstTimeInMilliseconds, runtime);
+          benchmark.bestTimeInMilliseconds
+            = Math.min(benchmark.bestTimeInMilliseconds, runtime);
+          benchmark.worstTimeInMilliseconds
+            = Math.max(benchmark.worstTimeInMilliseconds, runtime);
 
           ++benchmark.runs;
 
@@ -603,8 +600,8 @@ public class AnnisRunner extends AnnisBaseRunner
         continue;
       }
       boolean error = false;
-      SqlGeneratorAndExtractor<QueryData, ?> generator =
-        getGeneratorForQueryFunction(benchmark.functionCall);
+      SqlGeneratorAndExtractor<QueryData, ?> generator
+        = getGeneratorForQueryFunction(benchmark.functionCall);
       long start = new Date().getTime();
       try
       {
@@ -616,13 +613,13 @@ public class AnnisRunner extends AnnisBaseRunner
       }
       long end = new Date().getTime();
       long runtime = end - start;
-      
+
       benchmark.sumTimeInMilliseconds += runtime;
       benchmark.values.add(runtime);
-      benchmark.bestTimeInMilliseconds =
-        Math.min(benchmark.bestTimeInMilliseconds, runtime);
-      benchmark.worstTimeInMilliseconds =
-        Math.max(benchmark.worstTimeInMilliseconds, runtime);
+      benchmark.bestTimeInMilliseconds
+        = Math.min(benchmark.bestTimeInMilliseconds, runtime);
+      benchmark.worstTimeInMilliseconds
+        = Math.max(benchmark.worstTimeInMilliseconds, runtime);
 
       ++benchmark.runs;
       if (error)
@@ -642,11 +639,10 @@ public class AnnisRunner extends AnnisBaseRunner
       String options = benchmarkOptions(benchmark.queryData);
       out.println(benchmark.getMedian() + " ms (median for "
         + benchmark.runs + " runs" + (benchmark.errors > 0 ? ", "
-        + benchmark.errors + " errors)" : ")") + " for '"
+          + benchmark.errors + " errors)" : ")") + " for '"
         + benchmark.functionCall + ("".equals(options) ? "'" : "' with "
         + options));
     }
-
 
     // show best runtime for each query
     out.println();
@@ -656,7 +652,7 @@ public class AnnisRunner extends AnnisBaseRunner
       String options = benchmarkOptions(benchmark.queryData);
       out.println(benchmark.worstTimeInMilliseconds + " ms "
         + (benchmark.errors > 0 ? "("
-        + benchmark.errors + " errors)" : "") + " for '"
+          + benchmark.errors + " errors)" : "") + " for '"
         + benchmark.functionCall + ("".equals(options) ? "'" : "' with "
         + options));
     }
@@ -669,16 +665,16 @@ public class AnnisRunner extends AnnisBaseRunner
       String options = benchmarkOptions(benchmark.queryData);
       out.println(benchmark.bestTimeInMilliseconds + " ms "
         + (benchmark.errors > 0 ? "("
-        + benchmark.errors + " errors)" : "") + " for '"
+          + benchmark.errors + " errors)" : "") + " for '"
         + benchmark.functionCall + ("".equals(options) ? "'" : "' with "
         + options));
     }
     out.println();
 
     // CSV output
-    try(CSVWriter csv = new CSVWriter(new FileWriterWithEncoding(new File(
-        "annis_benchmark_result.csv"), "UTF-8"));)
-    { 
+    try (CSVWriter csv = new CSVWriter(new FileWriterWithEncoding(new File(
+      "annis_benchmark_result.csv"), "UTF-8"));)
+    {
 
       String[] header = new String[]
       {
@@ -704,33 +700,32 @@ public class AnnisRunner extends AnnisBaseRunner
     {
       log.error(null, ex);
     }
-    
-    
+
     // property output format for Jenkins Plot plugin
     try
     {
       File outputDir = new File("annis_benchmark_results");
-      if(outputDir.isDirectory() || outputDir.mkdirs())
+      if (outputDir.isDirectory() || outputDir.mkdirs())
       {
-        int i=1;
-        for(AnnisRunner.Benchmark b : benchmarks)
+        int i = 1;
+        for (AnnisRunner.Benchmark b : benchmarks)
         {
           Properties props = new Properties();
           props.put("YVALUE", "" + b.getMedian());
-          try (FileWriterWithEncoding writer = 
-            new FileWriterWithEncoding(new File(outputDir, i + ".properties"), "UTF-8"))
+          try (FileWriterWithEncoding writer
+            = new FileWriterWithEncoding(new File(outputDir, i + ".properties"), "UTF-8"))
           {
             props.store(writer, "");
           }
-          
+
           i++;
-          
+
           // also write out a "time" and "count" file which can be used by the ANNIS4 prototype
-          if(b.name != null)
+          if (b.name != null)
           {
             double mean = (double) b.sumTimeInMilliseconds / (double) b.runs;
             Files.write("" + mean, new File(outputDir, b.name + ".time"), StandardCharsets.UTF_8);
-            if(b.count != null)
+            if (b.count != null)
             {
               Files.write("" + b.count, new File(outputDir, b.name + ".count"), StandardCharsets.UTF_8);
             }
@@ -738,7 +733,7 @@ public class AnnisRunner extends AnnisBaseRunner
         }
       }
     }
-    catch(IOException ex)
+    catch (IOException ex)
     {
       log.error(null, ex);
     }
@@ -784,7 +779,7 @@ public class AnnisRunner extends AnnisBaseRunner
           if (dropCaches.canWrite())
           {
             log.debug("clearing file system cache");
-            try(Writer w = new FileWriterWithEncoding(dropCaches, "UTF-8");)
+            try (Writer w = new FileWriterWithEncoding(dropCaches, "UTF-8");)
             {
               w.write("3");
             }
@@ -861,9 +856,9 @@ public class AnnisRunner extends AnnisBaseRunner
         offset = Integer.parseInt(value);
       }
     }
-    else if("order".equals(setting))
+    else if ("order".equals(setting))
     {
-      if(show)
+      if (show)
       {
         value = order.toString();
       }
@@ -935,9 +930,9 @@ public class AnnisRunner extends AnnisBaseRunner
         clearCaches = Boolean.parseBoolean(value);
       }
     }
-    else if("bench-mode".equals(setting))
+    else if ("bench-mode".equals(setting))
     {
-      if(show)
+      if (show)
       {
         value = benchMode.name();
       }
@@ -947,7 +942,7 @@ public class AnnisRunner extends AnnisBaseRunner
         {
           benchMode = BenchmarkMode.valueOf(value);
         }
-        catch(IllegalArgumentException ex)
+        catch (IllegalArgumentException ex)
         {
           out.println("Invalid value, allowed values are: " + Joiner.on(", ").join(BenchmarkMode.values()));
         }
@@ -977,9 +972,9 @@ public class AnnisRunner extends AnnisBaseRunner
         segmentationLayer = value;
       }
     }
-    else if("filter".equals(setting))
+    else if ("filter".equals(setting))
     {
-      if(show)
+      if (show)
       {
         value = filter.name();
       }
@@ -988,15 +983,15 @@ public class AnnisRunner extends AnnisBaseRunner
         filter = SubgraphFilter.valueOf(value);
       }
     }
-    else if("freq-def".equals(setting))
+    else if ("freq-def".equals(setting))
     {
-      if(show)
+      if (show)
       {
         value = (frequencyDef == null ? "<not set>" : frequencyDef.toString());
       }
       else
       {
-          frequencyDef = FrequencyTableQuery.parse(value);
+        frequencyDef = FrequencyTableQuery.parse(value);
       }
     }
     else
@@ -1011,7 +1006,7 @@ public class AnnisRunner extends AnnisBaseRunner
   {
     doSet("?" + setting);
   }
-  
+
   public void doVersion(String ignore)
   {
     out.println(VersionInfo.getVersion());
@@ -1040,7 +1035,6 @@ public class AnnisRunner extends AnnisBaseRunner
     QueryData queryData;
     log.debug("analyze query for " + queryFunction + " function");
 
-
     if (queryFunction != null && !queryFunction.matches("(sql_)?subgraph"))
     {
       queryData = queryDao.parseAQL(annisQuery, corpusList);
@@ -1055,7 +1049,6 @@ public class AnnisRunner extends AnnisBaseRunner
     // filter by meta data
     queryData.setDocuments(metaDataFilter.getDocumentsForMetadata(queryData));
 
-
     if (queryFunction != null && queryFunction.matches("(sql_)?(annotate|find)"))
     {
       queryData.addExtension(new AnnotateQueryData(left, right,
@@ -1067,9 +1060,9 @@ public class AnnisRunner extends AnnisBaseRunner
       queryData.addExtension(new AnnotateQueryData(left, right,
         segmentationLayer, filter));
     }
-    else if(queryFunction != null && queryFunction.matches("(sql_)?frequency"))
+    else if (queryFunction != null && queryFunction.matches("(sql_)?frequency"))
     {
-      if(frequencyDef == null)
+      if (frequencyDef == null)
       {
         out.println("You have to set the 'freq-def' property first");
       }
@@ -1079,10 +1072,9 @@ public class AnnisRunner extends AnnisBaseRunner
       }
     }
 
-
     if (annisQuery != null)
     {
-      if(benchmarkName == null)
+      if (benchmarkName == null)
       {
         benchmarkName = "auto_" + benchmarks.size();
       }
@@ -1101,9 +1093,9 @@ public class AnnisRunner extends AnnisBaseRunner
   public void doCount(String annisQuery)
   {
     MatchAndDocumentCount count = queryDao.countMatchesAndDocuments(analyzeQuery(annisQuery, "count"));
-    if(!benchmarks.isEmpty())
+    if (!benchmarks.isEmpty())
     {
-      Benchmark lastBench = benchmarks.get(benchmarks.size()-1);
+      Benchmark lastBench = benchmarks.get(benchmarks.size() - 1);
       lastBench.count = count.getMatchCount();
     }
     out.println(count);
@@ -1131,11 +1123,11 @@ public class AnnisRunner extends AnnisBaseRunner
     MatchGroup group = new MatchGroup(matches);
     out.println(group.toString());
   }
-  
+
   public void doFrequency(String definitions)
-  {    
+  {
     FrequencyTable result = queryDao.frequency(analyzeQuery(definitions, "frequency"));
-    for(FrequencyTable.Entry e : result.getEntries())
+    for (FrequencyTable.Entry e : result.getEntries())
     {
       out.println(e.toString());
     }
@@ -1194,8 +1186,8 @@ public class AnnisRunner extends AnnisBaseRunner
   public void doAnnotations(String doListValues)
   {
     boolean listValues = "values".equals(doListValues);
-    List<AnnisAttribute> annotations =
-      queryDao.listAnnotations(getCorpusList(), listValues, true);
+    List<AnnisAttribute> annotations
+      = queryDao.listAnnotations(getCorpusList(), listValues, true);
     try
     {
       ObjectMapper om = new ObjectMapper();
@@ -1222,8 +1214,8 @@ public class AnnisRunner extends AnnisBaseRunner
       corpusIdAsList.add(Long.parseLong(corpusId));
       List<String> toplevelNames = queryDao.mapCorpusIdsToNames(corpusIdAsList);
 
-      List<Annotation> corpusAnnotations =
-        queryDao.listCorpusAnnotations(toplevelNames.get(0));
+      List<Annotation> corpusAnnotations
+        = queryDao.listCorpusAnnotations(toplevelNames.get(0));
       printAsTable(corpusAnnotations, "namespace", "name", "value");
     }
     catch (NumberFormatException ex)
@@ -1239,16 +1231,15 @@ public class AnnisRunner extends AnnisBaseRunner
       .splitToList(docCall);
 
     List<String> annoFilter = null;
-    if(splitted.size() > 2)
+    if (splitted.size() > 2)
     {
       annoFilter = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(
         splitted.get(2));
     }
-    
-    
+
     Validate.isTrue(splitted.size() > 1,
       "must have to arguments (toplevel corpus name and document name");
-    
+
     long corpusID = queryDao.mapCorpusNameToId(splitted.get(0));
     System.out.println(graphSqlGenerator.getDocumentQuery(
       corpusID,
@@ -1262,7 +1253,7 @@ public class AnnisRunner extends AnnisBaseRunner
       .splitToList(docCall);
 
     List<String> annoFilter = null;
-    if(splitted.size() > 2)
+    if (splitted.size() > 2)
     {
       annoFilter = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(
         splitted.get(2));
@@ -1270,18 +1261,18 @@ public class AnnisRunner extends AnnisBaseRunner
 
     Validate.isTrue(splitted.size() > 1,
       "must have two arguments (toplevel corpus name and document name");
-    SaltProject p = queryDao.retrieveAnnotationGraph(splitted.get(0), 
+    SaltProject p = queryDao.retrieveAnnotationGraph(splitted.get(0),
       splitted.get(1), annoFilter);
     System.out.println(printSaltAsXMI(p));
   }
-  
+
   public void doExport(String args)
   {
     List<String> splitted = Splitter.on(' ').trimResults().omitEmptyStrings()
       .limit(2)
       .splitToList(args);
     Validate.isTrue(splitted.size() == 2, "must have two arguments: toplevel corpus name and output directory");
-    
+
     queryDao.exportCorpus(splitted.get(0), new File(splitted.get(1)));
   }
 
@@ -1290,7 +1281,7 @@ public class AnnisRunner extends AnnisBaseRunner
     System.out.println("bye bye!");
     System.exit(0);
   }
-  
+
   public void doExit(String dummy)
   {
     System.out.println("bye bye!");
@@ -1370,7 +1361,6 @@ public class AnnisRunner extends AnnisBaseRunner
     this.countSqlGenerator = countSqlGenerator;
   }
 
-
   public SqlGeneratorAndExtractor<QueryData, List<Match>> getFindSqlGenerator()
   {
     return findSqlGenerator;
@@ -1412,5 +1402,5 @@ public class AnnisRunner extends AnnisBaseRunner
   {
     this.frequencySqlGenerator = frequencySqlGenerator;
   }
-  
+
 }


### PR DESCRIPTION
This PR enhances and fixes the annis.sh benchmark command by allowing to set different modes:

- warmup_random: first run each query 5 times as warm-up but do not collect the times in the result
- sequential_random: run the queries 5 times sequentially and than in random order and collect the times for both the sequental and random run.