### PR TITLE
Escape ',' in match ids

### DIFF
--- a/annis-interfaces/src/main/java/annis/service/objects/Match.java
+++ b/annis-interfaces/src/main/java/annis/service/objects/Match.java
@@ -176,7 +176,7 @@ public class Match implements Serializable
       URI uri;
       
       // undo any escaping
-      singleMatch = singleMatch.replace("%20", " ").replace("%25", "%");
+      singleMatch = singleMatch.replace("%20", " ").replace("%25", "%").replace("%2C", ",");
       
       String id = "";
       String anno = null;

--- a/annis-service/src/main/java/annis/sqlgen/SaltAnnotateExtractor.java
+++ b/annis-service/src/main/java/annis/sqlgen/SaltAnnotateExtractor.java
@@ -350,7 +350,7 @@ public class SaltAnnotateExtractor implements AnnotateExtractor<SaltProject>
     List<String> allUrisAsString = new LinkedList<>();
     for (URI u : match.getSaltIDs())
     {
-      allUrisAsString.add(u.toASCIIString());
+      allUrisAsString.add(u.toASCIIString().replace(",", "%2C"));
     }
     // set the matched keys
     SFeature featIDs = SaltFactory.createSFeature();


### PR DESCRIPTION
This is a simple fix for #576.