### PR TITLE
Add button to copy AQL

### DIFF
--- a/annis-gui/pom.xml
+++ b/annis-gui/pom.xml
@@ -190,6 +190,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.vaadin4qbanos</groupId>
+      <artifactId>jsclipboard</artifactId>
+      <version>1.0.12</version>
+    </dependency>
     
     <dependency>
       <groupId>de.hu-berlin.german.korpling.annis</groupId>

--- a/annis-gui/src/main/java/annis/gui/controlpanel/QueryPanel.java
+++ b/annis-gui/src/main/java/annis/gui/controlpanel/QueryPanel.java
@@ -25,6 +25,9 @@ import com.vaadin.data.util.BeanItemContainer;
 import com.vaadin.event.ShortcutAction.KeyCode;
 import com.vaadin.event.ShortcutAction.ModifierKey;
 import com.vaadin.event.ShortcutListener;
+import com.vaadin.event.FieldEvents.TextChangeEvent;
+import com.vaadin.event.FieldEvents.TextChangeListener;
+import com.vaadin.jsclipboard.JSClipboard;
 import com.vaadin.server.ClassResource;
 import com.vaadin.server.FontAwesome;
 import com.vaadin.server.ThemeResource;
@@ -33,6 +36,7 @@ import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Button.ClickListener;
 import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.ListSelect;
+import com.vaadin.ui.Notification;
 import com.vaadin.ui.ProgressBar;
 import com.vaadin.ui.TabSheet;
 import com.vaadin.ui.TabSheet.Tab;
@@ -224,6 +228,29 @@ public class QueryPanel extends GridLayout implements
       btShowKeyboard.setIcon(new ClassResource(VirtualKeyboardCodeEditor.class, "keyboard.png"));
       btShowKeyboard.addClickListener(new ShowKeyboardClickListener(virtualKeyboard));
     }
+    final JSClipboard clipboard = new JSClipboard();
+    Button btCopy = new Button("");
+    btCopy.setWidth("100%");
+    btCopy.setDescription("Click copy query to clipboard");
+    btShowKeyboard.addStyleName(ValoTheme.BUTTON_ICON_ONLY);
+    btCopy.addStyleName(ValoTheme.BUTTON_SMALL);
+    btCopy.setIcon(FontAwesome.COPY);
+    
+    clipboard.apply(btCopy, txtQuery);
+    txtQuery.addTextChangeListener(new TextChangeListener() {
+		
+		@Override
+		public void textChange(TextChangeEvent event) {
+			clipboard.setText(event.getText());
+		}
+	});
+    clipboard.addSuccessListener(new JSClipboard.SuccessListener() {
+		
+		@Override
+		public void onSuccess() {
+			Notification.show("Copied AQL to clipboard");
+		}
+	});
     
     Button btShowQueryBuilder = new Button("Query<br />Builder");
     btShowQueryBuilder.setHtmlContentAllowed(true);
@@ -267,37 +294,46 @@ public class QueryPanel extends GridLayout implements
      * Q: Query text field
      * QB: Button to toggle query builder // TODO
      * KEY: Button to show virtual keyboard
+     * COPY: Button for copying the text
      * SEA: "Search" button
      * MOR: "More actions" button 
      * HIST: "History" button
      * STAT: Text field with the real status
      * PROG: indefinite progress bar (spinning circle)
      * 
-     *   \  0  |  1  |  2  |  3  
+     *  \   0  |  1  |  2  |  3  
      * --+-----+---+---+---+-----
      * 0 |  Q  |  Q  |  Q  | QB 
      * --+-----+-----+-----+-----
      * 1 |  Q  |  Q  |  Q  | KEY 
      * --+-----+-----+-----+-----
-     * 2 | SEA | MOR | HIST|     
+     * 2 |  Q  |  Q  |  Q  | COPY
      * --+-----+-----+-----+-----
-     * 3 | STAT| STAT| STAT| PROG
+     * 3 | SEA | MOR | HIST|     
+     * --+-----+-----+-----+-----
+     * 4 | STAT| STAT| STAT| PROG
      */
-    addComponent(txtQuery, 0, 0, 2, 1);
-    addComponent(txtStatus, 0, 3, 2, 3);
-    addComponent(btShowResult, 0, 2);
-    addComponent(btMoreActions, 1, 2);
-    addComponent(btHistory, 2, 2);
-    addComponent(piCount, 3, 3);
+    addComponent(txtQuery, 0, 0, 2, 2);
+    addComponent(txtStatus, 0, 4, 2, 4);
+    addComponent(btShowResult, 0, 3);
+    addComponent(btMoreActions, 1, 3);
+    addComponent(btHistory, 2, 3);
+    addComponent(piCount, 3, 4);
     addComponent(btShowQueryBuilder, 3, 0);
     if(btShowKeyboard != null)
     {
       addComponent(btShowKeyboard, 3, 1);
+      addComponent(btCopy, 3, 2);
+    }
+    else
+    {
+      addComponent(btCopy, 3, 1);
     }
 
     // alignment
     setRowExpandRatio(0, 0.0f);
-    setRowExpandRatio(1, 1.0f);
+    setRowExpandRatio(1, 0.0f);
+    setRowExpandRatio(2, 1.0f);
     setColumnExpandRatio(0, 1.0f);
     setColumnExpandRatio(1, 0.0f);
     setColumnExpandRatio(2, 0.0f);

--- a/annis-gui/src/main/java/annis/gui/controlpanel/QueryPanel.java
+++ b/annis-gui/src/main/java/annis/gui/controlpanel/QueryPanel.java
@@ -25,8 +25,6 @@ import com.vaadin.data.util.BeanItemContainer;
 import com.vaadin.event.ShortcutAction.KeyCode;
 import com.vaadin.event.ShortcutAction.ModifierKey;
 import com.vaadin.event.ShortcutListener;
-import com.vaadin.event.FieldEvents.TextChangeEvent;
-import com.vaadin.event.FieldEvents.TextChangeListener;
 import com.vaadin.jsclipboard.JSClipboard;
 import com.vaadin.server.ClassResource;
 import com.vaadin.server.FontAwesome;
@@ -237,13 +235,15 @@ public class QueryPanel extends GridLayout implements
     btCopy.setIcon(FontAwesome.COPY);
     
     clipboard.apply(btCopy, txtQuery);
-    txtQuery.addTextChangeListener(new TextChangeListener() {
+    clipboard.setText(state.getAql().getValue());
+    state.getAql().addValueChangeListener(new ValueChangeListener() {
 		
 		@Override
-		public void textChange(TextChangeEvent event) {
-			clipboard.setText(event.getText());
+		public void valueChange(ValueChangeEvent event) {
+			clipboard.setText(event.getProperty().getValue().toString());
 		}
 	});
+    
     clipboard.addSuccessListener(new JSClipboard.SuccessListener() {
 		
 		@Override

--- a/annis-widgets/pom.xml
+++ b/annis-widgets/pom.xml
@@ -94,40 +94,6 @@
         <directory>src/main/resources</directory>
       </resource>
     </resources>
-    <pluginManagement>
-    	<plugins>
-    		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-    		<plugin>
-    			<groupId>org.eclipse.m2e</groupId>
-    			<artifactId>lifecycle-mapping</artifactId>
-    			<version>1.0.0</version>
-    			<configuration>
-    				<lifecycleMappingMetadata>
-    					<pluginExecutions>
-    						<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>com.vaadin</groupId>
-    								<artifactId>
-    									vaadin-maven-plugin
-    								</artifactId>
-    								<versionRange>
-    									[7.3.10,)
-    								</versionRange>
-    								<goals>
-    									<goal>update-widgetset</goal>
-    									<goal>resources</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-    					</pluginExecutions>
-    				</lifecycleMappingMetadata>
-    			</configuration>
-    		</plugin>
-    	</plugins>
-    </pluginManagement>
   </build>
 
   <repositories>


### PR DESCRIPTION
This copies the cleaned up version of AQL from the server state, thus e.g. Unicode left-to-right markers (LRM) are not included.