### PR TITLE
Restrict visjs keyboard shortcuts to elements

### DIFF
--- a/annis-visualizers/src/main/resources/annis/visualizers/component/visjs/VisJs_Connector.js
+++ b/annis-visualizers/src/main/resources/annis/visualizers/component/visjs/VisJs_Connector.js
@@ -85,9 +85,12 @@ enabled: true
 }
 },
 interaction: {
-  navigationButtons: true,
-  keyboard: true
-        },
+    navigationButtons: true,
+    keyboard: {
+        enabled: true,
+        bindToWindow: false
+    }
+},
 layout: {
 hierarchical:{
      direction: 'UD',


### PR DESCRIPTION
Fixes #573: Instead of binding the keyboard shortcuts to the whole
window (the visjs default), restrict them to the visjs elements in
focus.