### PR TITLE
Document REST-API inside the new developer guide

### DIFF
--- a/docs/src/mdbook/developer-guide/src/SUMMARY.md
+++ b/docs/src/mdbook/developer-guide/src/SUMMARY.md
@@ -5,4 +5,6 @@
 - [Making a new ANNIS release](./release.md)
 - [ANNIS import format version 3.3](./annisimportformat.md)
 - [Create new query builder](./querybuilder.md)
-- [Public REST API](./rest-api.md)
+- [Public REST API](./rest-api/README.md)
+	- [Corpus queries](./rest-api/query.md)
+	- [Administrative tasks](./rest-api/admin.md)

--- a/docs/src/mdbook/developer-guide/src/rest-api/README.md
+++ b/docs/src/mdbook/developer-guide/src/rest-api/README.md
@@ -15,9 +15,8 @@ You can omit any authentication data. In this case you have the same rights as t
 
 The following APIs are currently available:
 
-- Corpus queries as described by the `annis.service.QueryService` [interface](http://static.javadoc.io/de.hu-berlin.german.korpling.annis/annis-interfaces/${project.version}/annis/service/QueryService.html)
-- Administrative tasks as described by the `annis.service.AdminService` [interface](http://static.javadoc.io/de.hu-berlin.german.korpling.annis/annis-interfaces/${project.version}/annis/service/AdminService.html)
+- [Corpus queries](query.md) and
+- [Administrative tasks](admin.md)
 
-ANNIS uses the [semantic versioning scheme](http://semver.org/). Minor version updates of ANNIS will be backwards-compatible
-to the APIs described by this documentation. There might be further un-official API calls that might change without any
-notice.
+ANNIS uses the [semantic versioning scheme](http://semver.org/) for its REST-API. Minor version updates of ANNIS will be backwards-compatible to the APIs described by this documentation. 
+There might be further un-official API calls that might change without any notice.

--- a/docs/src/mdbook/developer-guide/src/rest-api/admin.md
+++ b/docs/src/mdbook/developer-guide/src/rest-api/admin.md
@@ -1,1 +1,33 @@
 # Administrative tasks
+
+Interface defining the REST API calls that ANNIS provides for administrative tasks.
+
+Currently it is possible to import corpora, monitor the import status with this interface and to manage user accounts.
+All paths for this part of the service start with "annis/admin/".
+
+## *Import* one or more corpora from an uploaded ZIP file 
+
+### Path(s)
+
+1. `POST` annis/admin/import
+
+### Request body
+
+A ZIP file which contains one or more corpora in separate sub-folders.
+Consumes MIME type `application/zip`.
+
+### Parameters
+
+- `overwrite` - Set to "true" if an existing corpus corpus should be overwritten.
+- `statusMail` - An e-mail address to which status reports are sent.
+- `alias` - An internal alias name of the corpus which can be used instead of the actual corpus name when referring to it in the URL. 
+
+### Responses
+
+#### Code 202 
+
+Import has been accepted and its status can be queried by the URL given in the `Location` header.
+
+#### Code 400
+
+Bad request, e.g. if the corpus already exists and `overwrite` parameter was not set.

--- a/docs/src/mdbook/developer-guide/src/rest-api/admin.md
+++ b/docs/src/mdbook/developer-guide/src/rest-api/admin.md
@@ -1,0 +1,1 @@
+# Administrative tasks

--- a/docs/src/mdbook/developer-guide/src/rest-api/admin.md
+++ b/docs/src/mdbook/developer-guide/src/rest-api/admin.md
@@ -5,7 +5,7 @@ Interface defining the REST API calls that ANNIS provides for administrative tas
 Currently it is possible to import corpora, monitor the import status with this interface and to manage user accounts.
 All paths for this part of the service start with "annis/admin/".
 
-## *Import* one or more corpora from an uploaded ZIP file 
+## *Import* one or more corpora
 
 ### Path(s)
 
@@ -20,7 +20,7 @@ Consumes MIME type `application/zip`.
 
 - `overwrite` - Set to "true" if an existing corpus corpus should be overwritten.
 - `statusMail` - An e-mail address to which status reports are sent.
-- `alias` - An internal alias name of the corpus which can be used instead of the actual corpus name when referring to it in the URL. 
+- `alias` - An internal alias name of the corpus which can be used instead of the actual corpus name when referring to it in the URL. Corpora can share the same alias.
 
 ### Responses
 
@@ -31,3 +31,48 @@ Import has been accepted and its status can be queried by the URL given in the `
 #### Code 400
 
 Bad request, e.g. if the corpus already exists and `overwrite` parameter was not set.
+
+## Show import job information after it was *finished*
+
+### Path(s)
+
+1. `GET` annis/admin/import/status/finished/**{uuid}**
+
+The **{uuid}** defines an unique identifier of the import job, which was returned by the [import function](#import-one-or-more-corpora).
+
+### Responses
+
+#### Code 200
+
+If the import finished, a 200 HTTP status code is sent and a proper description of the import job is returned.
+After this resource has been successfully accessed once, a 404 HTTP status code will be sent on subsequent requests.
+
+The response has the MIME type `application/xml` and the following format:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<importJob>
+  <!-- visible caption, e.g. corpus name  -->
+  <caption>MyNewCorpus</caption>
+  <!-- A list of output messages from the import process-->
+  <messages>
+    <m>first message</m>
+    <m>second message</m>
+    <m>just another message</m>
+  </messages>
+  <!-- true if the corpus will be overwritten -->
+  <overwrite>true</overwrite>
+  <!-- current status, can be WAITING, RUNNING, SUCCESS or ERROR -->
+  <status>RUNNING</status>
+  <!-- an unique identifier for this import job -->
+  <uuid>7799322d-83ec-4900-83b0-c542e2ca2137</uuid>
+  <!-- a mail address to which status reports should be send -->
+  <statusMail>mail@example.com</statusMail>
+  <!-- alias name of the corpus as defined by the import request -->
+  <alias>CorpusAlias</alias>
+</importJob>
+```
+
+#### Code 404
+
+When the import is not finished yet or if status was finished and already queries, a 404 HTTP status code will be sent.

--- a/docs/src/mdbook/developer-guide/src/rest-api/admin.md
+++ b/docs/src/mdbook/developer-guide/src/rest-api/admin.md
@@ -116,3 +116,40 @@ The response has the MIME type `application/xml` and the following format:
 #### Code 404
 
 When the import is not finished yet or if status was finished and already queries, a 404 HTTP status code will be sent.
+
+## Information about existing *users* 
+
+### Path(s)
+
+1. `GET` annis/admin/users/**{userName}**
+
+Gets information about an existing user with the name **{userName}**.
+
+### Responses
+
+#### Code 200
+
+If a user exists, return the user information with the MIME type `application/xml`.
+The fields correspond to the fields of the single user configuration file. 
+Please have a look at the general user configuration information in the ANNIS user guide for a more detailed explanation.
+
+```xml
+<user>
+  <!-- User name (must be the same as the "userName" parameter) -->
+  <name>myusername</name>
+  <!-- hashed password in the Shiro1CryptFormat -->
+  <passwordHash>$shiro1$SHA-256$1$tQNwU[...]</passwordHash>
+  <!-- A list of groups the users should belong to. -->
+  <group>group1</group>
+  <group>group2</group>
+  <group>group3</group>
+  <!-- A list of explicit permission the users should have. -->
+  <permission>admin:*</permission>
+  <permission>query:*</permission>
+  <!-- Optional expiration date encoded in the ISO-8601 standard</a> -->
+  <expires>2015-02-12T00:00:00.000+01:00</expires>
+</user>
+```
+
+- [Shiro1CryptFormat](http://shiro.apache.org/static/1.3.2/apidocs/org/apache/shiro/crypto/hash/format/Shiro1CryptFormat.html)
+- [ISO-8601 standard](https://en.wikipedia.org/wiki/ISO_8601)

--- a/docs/src/mdbook/developer-guide/src/rest-api/admin.md
+++ b/docs/src/mdbook/developer-guide/src/rest-api/admin.md
@@ -117,19 +117,44 @@ The response has the MIME type `application/xml` and the following format:
 
 When the import is not finished yet or if status was finished and already queries, a 404 HTTP status code will be sent.
 
-## Information about existing *users* 
+## *User* managment 
 
 ### Path(s)
 
 1. `GET` annis/admin/users/**{userName}**
+2. `PUT` annis/admin/users/**{userName}**
 
-Gets information about an existing user with the name **{userName}**.
+Gets information about an existing user with the name **{userName}** (1) or updates/creates a new user with this name (2).
+
+### Request body
+
+The `PUT` action accepts the user information in XML (MIME type`application/xml`). 
+The fields correspond to the fields of the single user configuration file. 
+Please have a look at the general user configuration information in the ANNIS user guide for a more detailed explanation.
+
+```xml
+<user>
+  <!-- User name (must be the same as the "userName" parameter) -->
+  <name>myusername</name>
+  <!-- hashed password in the Shiro1CryptFormat -->
+  <passwordHash>$shiro1$SHA-256$1$tQNwU[...]</passwordHash>
+  <!-- A list of groups the users should belong to. -->
+  <group>group1</group>
+  <group>group2</group>
+  <group>group3</group>
+  <!-- A list of explicit permission the users should have. -->
+  <permission>admin:*</permission>
+  <permission>query:*</permission>
+  <!-- Optional expiration date encoded in the ISO-8601 standard</a> -->
+  <expires>2015-02-12T00:00:00.000+01:00</expires>
+</user>
+```
 
 ### Responses
 
 #### Code 200
 
-If a user exists, return the user information with the MIME type `application/xml`.
+If the `GET` variant is used and the queried user exists, return the user information with the MIME type `application/xml`.
 The fields correspond to the fields of the single user configuration file. 
 Please have a look at the general user configuration information in the ANNIS user guide for a more detailed explanation.
 

--- a/docs/src/mdbook/developer-guide/src/rest-api/admin.md
+++ b/docs/src/mdbook/developer-guide/src/rest-api/admin.md
@@ -32,6 +32,46 @@ Import has been accepted and its status can be queried by the URL given in the `
 
 Bad request, e.g. if the corpus already exists and `overwrite` parameter was not set.
 
+## *Status* of all running import jobs
+
+### Path(s)
+
+1. `GET` annis/admin/import/status/
+
+### Responses
+
+#### Code 200
+
+The response lists all currently running import jobs has the MIME type `application/xml` and the following format:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<importJobs>
+  <!-- an importJob tag for each running import -->
+  <importJob>
+    <!-- visible caption, e.g. corpus name  -->
+    <caption>MyNewCorpus</caption>
+    <!-- A list of output messages from the import process-->
+    <messages>
+      <m>first message</m>
+      <m>second message</m>
+      <m>just another message</m>
+    </messages>
+    <!-- true if the corpus will be overwritten -->
+    <overwrite>true</overwrite>
+    <!-- current status, can be WAITING, RUNNING, SUCCESS or ERROR -->
+    <status>RUNNING</status>
+    <!-- an unique identifier for this import job -->
+    <uuid>7799322d-83ec-4900-83b0-c542e2ca2137</uuid>
+    <!-- a mail address to which status reports should be send -->
+    <statusMail>mail@example.com</statusMail>
+    <!-- alias name of the corpus as defined by the import request -->
+    <alias>CorpusAlias</alias>
+ </importJob>
+</importJobs>
+```
+The root element has the name `importJobs` and there is an `importJob` element for each element of the list. 
+
 ## Show import job information after it was *finished*
 
 ### Path(s)

--- a/docs/src/mdbook/developer-guide/src/rest-api/query.md
+++ b/docs/src/mdbook/developer-guide/src/rest-api/query.md
@@ -98,7 +98,7 @@ An ID can be prefixed by the fully qualified annotation name (which is separated
 
 ### Request body
 
-Accepts `application/xml`:
+Consumes `application/xml`:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -126,7 +126,7 @@ Accepts `application/xml`:
 </match-group>
 ```
 
-*or* accepts `text/plain`:
+*or* consumes `text/plain`:
 
 ```
 salt:/pcc2/11299/#tok_1 tiger::pos::salt:/pcc2/11299/#tok_2

--- a/docs/src/mdbook/developer-guide/src/rest-api/query.md
+++ b/docs/src/mdbook/developer-guide/src/rest-api/query.md
@@ -19,7 +19,9 @@ All paths for this part of the service start with the `annis/query/` prefix.
 ### Result
 
 Produces an XML representation of the total matches and the number of documents that contain matches (`application/xml`):
+
 ```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <matchAndDocumentCount>
   <!-- the number of documents that contain matches -->
   <documentCount>2</documentCount>
@@ -48,6 +50,7 @@ Produces an XML representation of the total matches and the number of documents 
 produces `application/xml`:
 
 ```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <match-group>
   <!-- each match is enclosed in an match tag -->
   <match>
@@ -70,8 +73,6 @@ produces `application/xml`:
   </match>
   <!-- and so on -->
 </match-group>
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<match-group>
 ```
 
 *or* produces: text/plain:
@@ -116,11 +117,9 @@ accepts `application/xml`:
   </match>
   <!-- and so on -->
 </match-group>
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<match-group>
 ```
 
-*or* accepts text/plain:
+*or* accepts `text/plain`:
 
 ```
 salt:/pcc2/11299/#tok_1 tiger::pos::salt:/pcc2/11299/#tok_2
@@ -138,3 +137,5 @@ One line per match, each ID is separated by space. An ID can be prepended by the
 - `filter` - Optional parameter with value "all" or "token". If "token" only token will be fetched. Default is "all". 
 
 ### Result
+
+Returns a representation of the [Salt](http://corpus-tools.org/salt/) annotation graph in the EMF XMI format and with MIME type `application/xml` or `application/xmi+xml`. 

--- a/docs/src/mdbook/developer-guide/src/rest-api/query.md
+++ b/docs/src/mdbook/developer-guide/src/rest-api/query.md
@@ -1,0 +1,84 @@
+# Corpus queries
+
+Interface defining the REST API calls that ANNIS provides for querying the data. 
+
+All paths for this part of the service start with the `annis/query/` prefix.
+
+## *Count* matches of an AQL query 
+
+### Path(s)
+
+- `GET annis/query/search/count` 
+
+
+### Parameters
+
+- `q` - The AQL query
+- `corpora` - A comma separated list of corpus names 
+
+### MIME
+
+Produces an XML representation of the total matches and the number of documents that contain matches (`application/xml`):
+```xml
+<matchAndDocumentCount>
+  <!-- the number of documents that contain matches -->
+  <documentCount>2</documentCount>
+  <!-- total number of matches -->
+  <matchCount>399</matchCount>
+</matchAndDocumentCount>
+```
+
+
+## *Find* matches for a given AQL query
+
+### Path(s)
+
+- `GET annis/query/search/find` 
+
+### Parameters
+
+- `q` - The AQL query 
+- `corpora` - A comma separated list of corpus names 
+- `offset` - Optional offset from where to start the matches. Default is 0. 
+- `limit` - Optional limit of the number of returned matches. Set to -1 if unlimited. Default is -1. 
+- `order` - Optional order how the results should be sorted. Can be either "normal", "random" or "inverted" "normal" is the default ordering, "inverted" inverses the default ordering and "random" is a non-stable (thus you will get different results for the same offset and limit) random ordering. 
+
+### MIME
+
+produces `application/xml`:
+
+```xml
+<match-group>
+  <!-- each match is enclosed in an match tag -->
+  <match>
+    <!-- the first matched node of match 1 did not match an annotation -->
+    <anno></anno>
+    <!-- the second matched node of match 1 was a match on the 'tiger::pos' annotation-->
+    <anno>tiger::pos</anno>
+    <!-- ID of first matched node of match 1 -->
+    <id>salt:/pcc2/11299/#tok_1</id>
+    <!-- ID of second matched noded  of match 1 -->
+    <id>salt:/pcc2/11299/#tok_2</id>
+  </match>
+  <match>
+    <anno></anno>
+    <anno>tiger::pos</anno>
+    <!-- ID of first matched noded of match 2 -->
+    <id>salt:/pcc2/11299/#tok_2</id>
+    <!-- ID of second matched noded of match 2-->
+    <id>salt:/pcc2/11299/#tok_3</id>
+  </match>
+  <!-- and so on -->
+</match-group>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<match-group>
+```
+
+*or* produces: text/plain:
+```
+salt:/pcc2/11299/#tok_1 tiger::pos::salt:/pcc2/11299/#tok_2
+salt:/pcc2/11299/#tok_2 tiger::pos::salt:/pcc2/11299/#tok_3
+salt:/pcc2/11299/#tok_3 tiger::pos::salt:/pcc2/11299/#tok_4
+```
+One line per match, each ID is separated by space. An ID can be prepended by the fully qualified annotation name (which is separated with '::' from the ID).
+

--- a/docs/src/mdbook/developer-guide/src/rest-api/query.md
+++ b/docs/src/mdbook/developer-guide/src/rest-api/query.md
@@ -191,10 +191,6 @@ In the latter case, you can specify the **{offset}** and the **{length}** of the
 - **{offset}** - Defines the offset from the the binary chunk starts (in bytes).
 - **{length}** - Defines the length of the binary chunk (in bytes).
 
-### Parameters
-
-No parameters.
-
 ### Responses
 
 #### Code 200

--- a/docs/src/mdbook/developer-guide/src/rest-api/query.md
+++ b/docs/src/mdbook/developer-guide/src/rest-api/query.md
@@ -16,7 +16,7 @@ All paths for this part of the service start with the `annis/query/` prefix.
 - `q` - The AQL query
 - `corpora` - A comma separated list of corpus names 
 
-### MIME
+### Result
 
 Produces an XML representation of the total matches and the number of documents that contain matches (`application/xml`):
 ```xml
@@ -43,7 +43,7 @@ Produces an XML representation of the total matches and the number of documents 
 - `limit` - Optional limit of the number of returned matches. Set to -1 if unlimited. Default is -1. 
 - `order` - Optional order how the results should be sorted. Can be either "normal", "random" or "inverted" "normal" is the default ordering, "inverted" inverses the default ordering and "random" is a non-stable (thus you will get different results for the same offset and limit) random ordering. 
 
-### MIME
+### Result
 
 produces `application/xml`:
 
@@ -82,3 +82,18 @@ salt:/pcc2/11299/#tok_3 tiger::pos::salt:/pcc2/11299/#tok_4
 ```
 One line per match, each ID is separated by space. An ID can be prepended by the fully qualified annotation name (which is separated with '::' from the ID).
 
+## Get a *subgraph* from a set of (matched) Salt IDs. 
+
+### Path(s)
+
+- `POST annis/query/search/subgraph`
+
+
+### Parameters
+
+- `segmentation` - Optional parameter for segmentation layer on which the context is applied. Leave empty for token layer (which is default).
+- `left` - Optional parameter for the left context size, default is 0.
+- `right` - Optional parameter for the right context size, default is 0.
+- `filter` - Optional parameter with value "all" or "token". If "token" only token will be fetched. Default is "all". 
+
+### Result

--- a/docs/src/mdbook/developer-guide/src/rest-api/query.md
+++ b/docs/src/mdbook/developer-guide/src/rest-api/query.md
@@ -2,21 +2,23 @@
 
 Interface defining the REST API calls that ANNIS provides for querying the data. 
 
-All paths for this part of the service start with the `annis/query/` prefix.
+All paths for this part of the service start with the "annis/query/" prefix.
 
-## *Count* matches of an AQL query 
+## *Count* matches of a query 
 
 ### Path(s)
 
-- `GET annis/query/search/count` 
+1. `GET` annis/query/search/count
 
 
 ### Parameters
 
-- `q` - The AQL query
+- `q` - The query in the ANNIS Query Language (AQL)
 - `corpora` - A comma separated list of corpus names 
 
-### Result
+### Responses
+
+#### Code 200
 
 Produces an XML representation of the total matches and the number of documents that contain matches (`application/xml`):
 
@@ -31,23 +33,27 @@ Produces an XML representation of the total matches and the number of documents 
 ```
 
 
-## *Find* matches for a given AQL query
+## *Find* matches for a given query
 
 ### Path(s)
 
-- `GET annis/query/search/find` 
+1. `GET` annis/query/search/find 
 
 ### Parameters
 
-- `q` - The AQL query 
+- `q` - The query in the ANNIS Query Language (AQL)
 - `corpora` - A comma separated list of corpus names 
 - `offset` - Optional offset from where to start the matches. Default is 0. 
 - `limit` - Optional limit of the number of returned matches. Set to -1 if unlimited. Default is -1. 
 - `order` - Optional order how the results should be sorted. Can be either "normal", "random" or "inverted" "normal" is the default ordering, "inverted" inverses the default ordering and "random" is a non-stable (thus you will get different results for the same offset and limit) random ordering. 
 
-### Result
+### Responses
 
-produces `application/xml`:
+#### Code 200
+
+A list of the match identifiers for the query.
+
+Can produce the MIME type `application/xml` in the following format
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -75,23 +81,24 @@ produces `application/xml`:
 </match-group>
 ```
 
-*or* produces: text/plain:
+*or* the MIME type `text/plain`
 ```
 salt:/pcc2/11299/#tok_1 tiger::pos::salt:/pcc2/11299/#tok_2
 salt:/pcc2/11299/#tok_2 tiger::pos::salt:/pcc2/11299/#tok_3
 salt:/pcc2/11299/#tok_3 tiger::pos::salt:/pcc2/11299/#tok_4
 ```
-One line per match, each ID is separated by space. An ID can be prepended by the fully qualified annotation name (which is separated with '::' from the ID).
+In this format, there is one line per match and each ID is separated by space.
+An ID can be prefixed by the fully qualified annotation name (which is separated with '::' from the ID).
 
-## Get a *subgraph* from a set of (matched) Salt IDs. 
+## Get a *subgraph* from a set of (matched) Salt IDs
 
 ### Path(s)
 
-- `POST annis/query/search/subgraph`
+1. `POST` annis/query/search/subgraph
 
-## Request body
+### Request body
 
-accepts `application/xml`:
+Accepts `application/xml`:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -136,6 +143,61 @@ One line per match, each ID is separated by space. An ID can be prepended by the
 - `right` - Optional parameter for the right context size, default is 0.
 - `filter` - Optional parameter with value "all" or "token". If "token" only token will be fetched. Default is "all". 
 
-### Result
+### Responses
+
+#### Code 200
 
 Returns a representation of the [Salt](http://corpus-tools.org/salt/) annotation graph in the EMF XMI format and with MIME type `application/xml` or `application/xmi+xml`. 
+
+## Get the annotation *graph* of a complete document
+
+### Path(s)
+
+1. `GET` annis/query/graph/**{top}**/**{doc}**
+
+**{top}** is the toplevel corpus name of the document and **{doc}** the document name. 
+
+### Parameters
+
+- `filternodeanno` - 	A comma seperated list of node annotations which are used as a filter for the graph. Only nodes having one of the annotations are included in the result. 
+
+### Responses
+
+#### Code 200
+
+Returns a representation of the [Salt](http://corpus-tools.org/salt/) annotation graph in the EMF XMI format and with MIME type `application/xml` or `application/xmi+xml`. 
+
+## Get the content a *binary* object for a specific document
+
+### Path(s)
+
+1. `GET` annis/query/corpora/**{top}**/**{document}**/binary 
+2. `GET` annis/query/corpora/**{top}**/**{document}**/binary/**{offset}**/**{length}**
+3. `GET` annis/query/corpora/**{top}**/**{document}**/binary/**{file}**
+4. `GET` annis/query/corpora/**{top}**/**{document}**/binary/**{file}**/**{offset}**/**{length}**
+
+Accepts any MIME type. The MIME type is used as implicit argument to filter the files that match a given query. 
+
+There are several ways of selecting the binary data you want to receive. 
+You can choose to select the file only by giving a document name given by the **{top}** and **{document}** arguments (paths 1 and 2). 
+This will return the first file that also matches the requested accepted mime types. 
+Alternatively the name of the file itself can be given as path argument **{file}** (paths 3 and 4).
+You can also choose to either get the complete file (paths 1 and 3) or chunks containing only a subset of the binary data (paths 2 and 4). 
+In the latter case, you can specify the **{offset}** and the **{length}** of the chunk (both in bytes).
+
+- **{top}** - The toplevel corpus name. 
+- **{document}** - The name of the document that has the file. If you want the files for the toplevel corpus itself, use the name of the toplevel corpus as document name. 
+- **{file}** - File name/title to select.
+- **{offset}** - Defines the offset from the the binary chunk starts (in bytes).
+- **{length}** - Defines the length of the binary chunk (in bytes).
+
+### Parameters
+
+No parameters.
+
+### Responses
+
+#### Code 200
+
+A binary stream that contains the file content. If path variant 2 and 4 is used only a subset of the file is returned. 
+Path variant 1 and 3 always return the complete file.

--- a/docs/src/mdbook/developer-guide/src/rest-api/query.md
+++ b/docs/src/mdbook/developer-guide/src/rest-api/query.md
@@ -88,6 +88,47 @@ One line per match, each ID is separated by space. An ID can be prepended by the
 
 - `POST annis/query/search/subgraph`
 
+## Request body
+
+accepts `application/xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<match-group>
+  <!-- each match is enclosed in an match tag -->
+  <match>
+    <!-- the first matched node of match 1 did not match an annotation -->
+    <anno></anno>
+    <!-- the second matched node of match 1 was a match on the 'tiger::pos' annotation-->
+    <anno>tiger::pos</anno>
+    <!-- ID of first matched node of match 1 -->
+    <id>salt:/pcc2/11299/#tok_1</id>
+    <!-- ID of second matched noded  of match 1 -->
+    <id>salt:/pcc2/11299/#tok_2</id>
+  </match>
+  <match>
+    <anno></anno>
+    <anno>tiger::pos</anno>
+    <!-- ID of first matched noded of match 2 -->
+    <id>salt:/pcc2/11299/#tok_2</id>
+    <!-- ID of second matched noded of match 2-->
+    <id>salt:/pcc2/11299/#tok_3</id>
+  </match>
+  <!-- and so on -->
+</match-group>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<match-group>
+```
+
+*or* accepts text/plain:
+
+```
+salt:/pcc2/11299/#tok_1 tiger::pos::salt:/pcc2/11299/#tok_2
+salt:/pcc2/11299/#tok_2 tiger::pos::salt:/pcc2/11299/#tok_3
+salt:/pcc2/11299/#tok_3 tiger::pos::salt:/pcc2/11299/#tok_4
+```
+
+One line per match, each ID is separated by space. An ID can be prepended by the fully qualified annotation name (which is separated with '::' from the ID).
 
 ### Parameters
 


### PR DESCRIPTION
Instead of linking to the broken javadoc, document the REST-API directly.