### PR TITLE
Show signals in RST visualizer

### DIFF
--- a/annis-visualizers/src/main/java/annis/visualizers/component/rst/RSTImpl.java
+++ b/annis-visualizers/src/main/java/annis/visualizers/component/rst/RSTImpl.java
@@ -345,18 +345,16 @@ public class RSTImpl extends Panel implements GraphTraverseHandler {
 
       // build strings
       Iterator<SToken> tokIterator = token.iterator();
-      int tokCount = 0;
       while(tokIterator.hasNext())
       {
         SToken tok = tokIterator.next();
         String text = getText(tok);
         String color = getHTMLColor(tok);
-        tokCount++;
 
         if (color != null) {
-          sb.append("<span id=\"tok").append(tokCount).append("\" style=\"color : ").append(color).append(";\">");
+          sb.append("<span class=\"token\" style=\"color : ").append(color).append(";\">");
         } else {
-          sb.append("<span id=\"tok").append(tokCount).append("\">");
+          sb.append("<span class=\"token\">");
         }
 
         if (tokIterator.hasNext()) {

--- a/annis-visualizers/src/main/java/annis/visualizers/component/rst/RSTImpl.java
+++ b/annis-visualizers/src/main/java/annis/visualizers/component/rst/RSTImpl.java
@@ -326,6 +326,7 @@ public class RSTImpl extends Panel implements GraphTraverseHandler {
 
   private JSONObject createJsonEntry(SNode currNode) {
     JSONObject jsonData = new JSONObject();
+    JSONObject data = new JSONObject();
     StringBuilder sb = new StringBuilder();
     // use a hash set so we don't get any duplicate entries
     LinkedHashSet<SToken> token = new LinkedHashSet<>();
@@ -365,6 +366,17 @@ public class RSTImpl extends Panel implements GraphTraverseHandler {
 
         sb.append("</span>");
       }
+
+      // add signals
+      JSONArray signals = new JSONArray();
+      for (SRelation<SNode, SNode> relation : currNode.getInRelations()) {
+        if (isSignalNode(relation.getSource())) {
+          signals.put(jsonizeSignalNode(relation.getSource()));
+        }
+      }
+      if (signals.length() > 0) {
+        data.put("signals", signals);
+      }
     }
 
     try {
@@ -375,7 +387,6 @@ public class RSTImpl extends Panel implements GraphTraverseHandler {
       /**
        * additional data oject for edge labels and rendering sentences
        */
-      JSONObject data = new JSONObject();
       JSONArray edgesJSON = getOutGoingEdgeTypeAnnotation(currNode);
 
 
@@ -397,16 +408,6 @@ public class RSTImpl extends Panel implements GraphTraverseHandler {
 
         data.put(SENTENCE_LEFT, index);
         data.put(SENTENCE_RIGHT, index);
-
-        JSONArray signals = new JSONArray();
-        for (SRelation<SNode, SNode> relation : currNode.getInRelations()) {
-          if (isSignalNode(relation.getSource())) {
-            signals.put(jsonizeSignalNode(relation.getSource()));
-          }
-        }
-        if (signals.length() > 0) {
-          data.put("signals", signals);
-        }
       }
 
       jsonData.put("data", data);

--- a/annis-visualizers/src/main/java/annis/visualizers/component/rst/RSTImpl.java
+++ b/annis-visualizers/src/main/java/annis/visualizers/component/rst/RSTImpl.java
@@ -309,6 +309,22 @@ public class RSTImpl extends Panel implements GraphTraverseHandler {
     return result.toString();
   }
 
+  private JSONObject jsonizeSignalNode(SNode node) {
+    JSONObject signal = new JSONObject();
+    signal.put("type", node.getAnnotation("default_ns", "signal_type").getValue());
+    signal.put("subtype", node.getAnnotation("default_ns", "signal_subtype").getValue());
+    JSONArray indexes = new JSONArray();
+    SAnnotation indexesAnn = node.getAnnotation("default_ns", "signal_indexes");
+    if (indexesAnn != null) {
+      for (String index : ((String) indexesAnn.getValue()).split(" ")) {
+        indexes.put(index);
+      }
+    }
+    signal.put("indexes", indexes);
+    System.out.println(signal);
+    return signal;
+  }
+
   private JSONObject createJsonEntry(SNode currNode) {
     JSONObject jsonData = new JSONObject();
     StringBuilder sb = new StringBuilder();
@@ -382,6 +398,16 @@ public class RSTImpl extends Panel implements GraphTraverseHandler {
 
         data.put(SENTENCE_LEFT, index);
         data.put(SENTENCE_RIGHT, index);
+
+        JSONArray signals = new JSONArray();
+        for (SRelation<SNode, SNode> relation : currNode.getInRelations()) {
+          if (isSignalNode(relation.getSource())) {
+            signals.put(jsonizeSignalNode(relation.getSource()));
+          }
+        }
+        if (signals.length() > 0) {
+          data.put("signals", signals);
+        }
       }
 
       jsonData.put("data", data);

--- a/annis-visualizers/src/main/java/annis/visualizers/component/rst/RSTImpl.java
+++ b/annis-visualizers/src/main/java/annis/visualizers/component/rst/RSTImpl.java
@@ -321,7 +321,6 @@ public class RSTImpl extends Panel implements GraphTraverseHandler {
       }
     }
     signal.put("indexes", indexes);
-    System.out.println(signal);
     return signal;
   }
 

--- a/annis-visualizers/src/main/java/annis/visualizers/component/rst/RSTImpl.java
+++ b/annis-visualizers/src/main/java/annis/visualizers/component/rst/RSTImpl.java
@@ -345,16 +345,18 @@ public class RSTImpl extends Panel implements GraphTraverseHandler {
 
       // build strings
       Iterator<SToken> tokIterator = token.iterator();
+      int tokCount = 0;
       while(tokIterator.hasNext())
       {
         SToken tok = tokIterator.next();
         String text = getText(tok);
         String color = getHTMLColor(tok);
+        tokCount++;
 
         if (color != null) {
-          sb.append("<span style=\"color : ").append(color).append(";\">");
+          sb.append("<span id=\"tok").append(tokCount).append("\" style=\"color : ").append(color).append(";\">");
         } else {
-          sb.append("<span>");
+          sb.append("<span id=\"tok").append(tokCount).append("\">");
         }
 
         if (tokIterator.hasNext()) {

--- a/annis-visualizers/src/main/java/annis/visualizers/component/rst/RSTImpl.java
+++ b/annis-visualizers/src/main/java/annis/visualizers/component/rst/RSTImpl.java
@@ -233,17 +233,22 @@ public class RSTImpl extends Panel implements GraphTraverseHandler {
     this.getContent().setSizeUndefined();
   }
 
+  private boolean isSignalNode(SNode sNode) {
+    return sNode.getAnnotation("default_ns", "signal_type") != null;
+  }
+
   private String transformSaltToJSON(VisualizerInput visInput) {
     graph = visInput.getSResult().getDocumentGraph();
     List<SNode> rootSNodes = graph.getRoots();
     List<SNode> rstRoots = new ArrayList<SNode>();
 
-
     for (SNode sNode : rootSNodes) {
-      if (CommonHelper.checkSLayer(namespace, sNode)) {
+      if (CommonHelper.checkSLayer(namespace, sNode)
+              && !isSignalNode(sNode)) {
         rstRoots.add(sNode);
       }
     }
+
 
 
     if (rootSNodes.size() > 0) {
@@ -256,7 +261,8 @@ public class RSTImpl extends Panel implements GraphTraverseHandler {
                 String traversalId, SNode currNode, SRelation sRelation,
                 SNode fromNode, long order) {
           if (currNode instanceof SStructure
-                  && isSegment(currNode)) {
+                  && isSegment(currNode)
+                  && !isSignalNode(currNode)) {
             sentences.add((SStructure) currNode);
           }
         }

--- a/annis-visualizers/src/main/java/annis/visualizers/component/rst/RSTImpl.java
+++ b/annis-visualizers/src/main/java/annis/visualizers/component/rst/RSTImpl.java
@@ -353,9 +353,9 @@ public class RSTImpl extends Panel implements GraphTraverseHandler {
         String color = getHTMLColor(tok);
 
         if (color != null) {
-          sb.append("<span class=\"token\" style=\"color : ").append(color).append(";\">");
+          sb.append("<span class=\"rst-token\" style=\"color : ").append(color).append(";\">");
         } else {
-          sb.append("<span class=\"token\">");
+          sb.append("<span class=\"rst-token\">");
         }
 
         if (tokIterator.hasNext()) {

--- a/annis-widgets/src/main/java/annis/gui/widgets/rst_vis.js
+++ b/annis-widgets/src/main/java/annis/gui/widgets/rst_vis.js
@@ -189,7 +189,7 @@
 					  + "}"
 
 					  + ".rst-signal-list {"
-					  + "  display: none;"
+					  + "  opacity: 0;"
 					  + "  position: absolute;"
 					  + "  background: white;"
 					  + "  bottom: 10px;"
@@ -198,6 +198,7 @@
 					  + "  list-style: none;"
 					  + "  padding: 0;"
 					  + "  box-shadow: 2px 2px 5px 2px #cccccc;"
+					  + "  z-index: 1337;"
 					  + "}"
 
 					  + ".rst-signal-list li {"
@@ -222,8 +223,40 @@
 					  + ".rst-node {}"
 
 					  + ".rst-node:hover .rst-signal-list {"
-					  + "  display: block;"
+					  + "  opacity: 1;"
+					  + "  transition-duration: 0.3s;"
 					  + "  transition-delay: 0.5s;"
+					  + "  transition-property: opacity;"
+					  + "}"
+
+					  + ".badge {"
+					  + "  width: 11px;"
+					  + "  height: 11px;"
+					  + "  font-size: 9px;"
+					  + "  border: solid 1px;"
+					  + "  border-radius: 8px;"
+					  + "  padding: 0;"
+					  + "  margin: 0 0 0 0.5em;"
+					  + "  background-color: #f7f7f7;"
+					  + "  color: black;"
+					  + "  display: inline-block;"
+					  + "}"
+
+					  + ".rst-node:hover .badge {"
+					  + "  background-color: yellow;"
+					  + "  transition-duration: 0.3s;"
+					  + "  transition-delay: 0.5s;"
+					  + "  transition-property: background-color;"
+					  + "}"
+
+					  + ".rst-token--highlighted {"
+					  + "  background-color: yellow;"
+					  + "}"
+
+					  + "#show-all-tokens {"
+					  + "  position: absolute;
+					  + "  top: 10px;
+					  + "  right: 10px;
 					  + "}"
 					  );
 			style.innerHTML = css;
@@ -388,13 +421,23 @@
 					canvas.setAttribute("height", top + "px");
 				}
 
-				// add signal list, if present
+				// add signal badge and list, if signals are present
 				var signals = json.data.signals;
 				if (signals && signals.length > 0) {
 					var signalListElt = createSignalList(conf, json, signals);
 					nodeIdElt.appendChild(signalListElt);
+
+					var signalBadge = createSignalBadge(signals);
+					nodeIdElt.appendChild(signalBadge);
 				}
 			}
+		}
+
+		function createSignalBadge(signals) {
+			var badge = document.createElement("div");
+			badge.classList.add("badge");
+			badge.innerText = signals.length;
+			return badge;
 		}
 
 		function createSignalList(conf, node, signals) {
@@ -412,6 +455,20 @@
 		function createSignalListItem(conf, node, signal) {
 			var elt = document.createElement("li");
 			elt.innerHTML = signal.type + ", " + signal.subtype;
+			elt.addEventListener("click", function() {
+				var tokens = document.querySelectorAll("span.rst-token");
+				var highlightedTokens = document.querySelectorAll("span.rst-token--highlighted");
+				var indexes = signal.indexes;
+				var i;
+
+				for (i = 0; i < highlightedTokens.length; i++) {
+					highlightedTokens[i].classList.remove("rst-token--highlighted");
+				}
+				for (i = 0; i < indexes.length; i++) {
+					var tokenListIndex = indexes[i] - 1;
+					tokens[tokenListIndex].classList.add("rst-token--highlighted");
+				}
+			});
 
 			return elt;
 		}

--- a/annis-widgets/src/main/java/annis/gui/widgets/rst_vis.js
+++ b/annis-widgets/src/main/java/annis/gui/widgets/rst_vis.js
@@ -211,6 +211,7 @@
 					  + "  background: white;"
 					  + "  transition-duration: 0.5s;"
 					  + "  transition-property: background;"
+					  + "  white-space: normal;"
 					  + "}"
 
 					  + ".rst-signal-list-item:last-child {"

--- a/annis-widgets/src/main/java/annis/gui/widgets/rst_vis.js
+++ b/annis-widgets/src/main/java/annis/gui/widgets/rst_vis.js
@@ -257,7 +257,7 @@
 					  + "}"
 
 					  + ".rst-relation:hover .badge {"
-					  + "  background-color: rgba(255, 255, 0, 0.5);"
+					  + "  background-color: rgba(255, 255, 0);"
 					  + "  transition-duration: 0.3s;"
 					  + "  transition-delay: 0.5s;"
 					  + "  transition-property: background-color;"
@@ -762,7 +762,7 @@
 
 				var labelPos = {
 					x : child.pos.x,
-					y : source.pos.y + config.subTreeOffset / 2
+					y : child.pos.y - 20
 				}
 
 				label.style.top = labelPos.y + "px";

--- a/annis-widgets/src/main/java/annis/gui/widgets/rst_vis.js
+++ b/annis-widgets/src/main/java/annis/gui/widgets/rst_vis.js
@@ -450,6 +450,11 @@
 			}
 		}
 
+		/**
+		 * A small circular icon that indicates how many signals are associated with a particular relation.
+		 * @param {signals}
+		 *            the list of signals associated with this node
+		 */
 		function createSignalBadge(signals) {
 			var badge = document.createElement("div");
 			badge.classList.add("badge");
@@ -457,6 +462,21 @@
 			return badge;
 		}
 
+		/**
+		 * A hovering list that appears when a relation is hovered over. Items represent individual signals and
+		 * can be clicked.
+		 *
+		 * @param {conf}
+		 *            holds the config of rst visualization
+		 * @param {node}
+		 *            the JS object representing the node currently being drawn in plotNodes
+		 * @param {signals}
+		 *            the list of signals associated with this node
+		 * @param {badgeElt}
+		 *            a reference to the badge element
+		 * @param {tokenCount}
+		 *            an array mapping from token index to number of times a signal has highlighted it
+		 */
 		function createSignalList(conf, node, signals, badgeElt, tokenCount) {
 			var list = document.createElement("ul");
 			list.classList.add("rst-signal-list");
@@ -469,10 +489,25 @@
 			return list;
 		}
 
+		/**
+		 * Represents an individual signal.
+		 *
+		 * @param {conf}
+		 *            holds the config of rst visualization
+		 * @param {node}
+		 *            the JS object representing the node currently being drawn in plotNodes
+		 * @param {signal}
+		 *            a JS object representing an individual signal
+		 * @param {badgeElt}
+		 *            a reference to the badge element
+		 * @param {tokenCount}
+		 *            an array mapping from token index to number of times a signal has highlighted it
+		 */
 		function createSignalListItem(conf, node, signal, badgeElt, tokenCount) {
 			var elt = document.createElement("li");
 			elt.classList.add("rst-signal-list-item");
 			elt.innerHTML = signal.type + ", " + signal.subtype;
+
 			elt.addEventListener("click", function() {
 				var tokens = conf.containerElement.querySelectorAll("span.rst-token");
 				var indexes = signal.indexes;
@@ -486,6 +521,11 @@
 					badgeElt.classList.remove("badge--highlighted");
 				}
 
+				// Need to be careful not to de-select a token if another signal was already selected that highlighted
+				// the same token. We keep track of how many times a token has been highlighted by a signal in the
+				// tokenCount array: when a signal highlights a token, the count for that token is increased by 1,
+				// and when a signal "unhighlights" a token, it is only unhighlighted if no other tokens have
+				// highlighted that token, i.e. if tokenCount[index] is 0.
 				for (i = 0; i < indexes.length; i++) {
 					var tokenListIndex = indexes[i] - 1;
 					var existingCount = tokenCount[tokenListIndex];
@@ -506,6 +546,9 @@
 
 		/**
 		 * recursive helper that finds all signals
+		 *
+		 * @param {json}
+		 *            the JS object representing the entire RST data structure
 		 */
 		function findAllSignals(json) {
 			var signals = [];
@@ -526,6 +569,15 @@
 			return signals;
 		}
 
+
+		/**
+		 * Create a button that semi-highlights all tokens associated with a signal when pressed.
+		 *
+		 * @param {conf}
+		 *            holds the config of rst visualization
+		 * @param {tokenCount}
+		 *            an array mapping from token index to number of times a signal has highlighted it
+		 */
 		function createShowAllSignalsButton(conf, tokenCount) {
 			var signals = findAllSignals(conf.json);
 			if (signals.length === 0) {
@@ -539,6 +591,11 @@
 			button.innerText = offText;
 
 			var tokens = conf.containerElement.querySelectorAll("span.rst-token");
+
+			// This button, when activated, adds a slight highlight to all tokens that are associated with at least one
+			// signal in the document. When it is deactivated, not only this slight highlight is removed, but all other
+			// signal-related state is also removed. This includes badge, signal list item, and token selections, as
+			// well as the state of tokenCount (see createSignalListItem).
 			button.addEventListener("click", function() {
 				if (button.innerText === offText) {
 					signals.forEach(function(signal) {

--- a/annis-widgets/src/main/java/annis/gui/widgets/rst_vis.js
+++ b/annis-widgets/src/main/java/annis/gui/widgets/rst_vis.js
@@ -12,7 +12,9 @@
 		 * http://killdream.github.com/blog/2011/10/understanding-javascript-oop
 		 */
 		// Aliases for the rather verbose methods on ES5
-		var descriptor = Object.getOwnPropertyDescriptor, properties = Object.getOwnPropertyNames, define_prop = Object.defineProperty
+		var descriptor = Object.getOwnPropertyDescriptor;
+		var properties = Object.getOwnPropertyNames;
+		var define_prop = Object.defineProperty;
 
 		// (target:Object, source:Object) → Object
 		// Copies properties from `source' to `target'
@@ -289,7 +291,10 @@
 				container.appendChild(elem);
 
 				if (json.data.sentence_left != undefined && json.data.sentence_right != undefined) {
-					elem.innerHTML = "<p style='color :" + conf.nodeLabelColor + ";'>" + (json.data.sentence_left + " - " + json.data.sentence_right) + "</p>";
+					var eduRange = json.data.sentence
+						? json.name
+						: (json.data.sentence_left + " - " + json.data.sentence_right);
+					elem.innerHTML = "<p style='color :" + conf.nodeLabelColor + ";'>" + eduRange + "</p>";
 				}
 
 				elem.innerHTML += (json.data.sentence != undefined) ? json.data.sentence : "";
@@ -509,7 +514,7 @@
 			};
 
 			/**
-			 * Calls the necassary functions to plot edges and to place labels.
+			 * Calls the necessary functions to plot edges and to place labels.
 			 */
 			this.init = function() {
 				layoutTree(this.config);


### PR DESCRIPTION
(**Note**: for your convenience I'm running a demo server for this PR. Please send me an email for the address, I'd prefer not to post it publicly.)

This PR adds support for signals to the RST visualizer. In RST, "signals" are pieces of evidence, such as a telling word, that act as cues for a reader/listener as they attempt to find the appropriate relation between two discourse units. 

This extension parallels the visual approach used when signal support was added to [rstWeb](https://github.com/amir-zeldes/rstWeb), and assumes the presence of Salt structures like those produced by the [RST Pepper module](https://github.com/korpling/pepperModules-RSTModules/commits/develop), which in turn can be produced by exporting .RS4 XML from rstWeb and put through Pepper.

A sample screenshot:
![](https://i.imgur.com/NsumRoU.png)