### PR TITLE
Allow underscores and % in regular expression for the node name definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create multiple textual data sources in Salt document for parallel corpora instead of merging them into one STextualDS
 - When querying multiple corpora at once, getting the next page could fail because of some issues with the offset generation
+- Allow underscore in named node critera [#643](https://github.com/korpling/ANNIS/issues/643)
 
 ## [4.0.0-beta.3] - 2019-10-18
 

--- a/annis-gui/src/main/resources/annis/gui/components/codemirror/mode/aql/aql.js
+++ b/annis-gui/src/main/resources/annis/gui/components/codemirror/mode/aql/aql.js
@@ -173,7 +173,7 @@ CodeMirror.defineMode("aql", function(config, parserConfig) {
             return addNode(state);
           }
         }
-        else if(stream.match(/#[0-9a-zA-Z]+/))
+        else if(stream.match(/#[a-zA-Z0-9_\-%]+/))
         {
           return "variable-2";
         }


### PR DESCRIPTION
This fixes #643.