### PR TITLE
Use tomlj for parsing the TOML files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,10 @@
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
-	<groupId>de.hu-berlin.german.korpling.annis</groupId>
-	<artifactId>annis-gui</artifactId>
+	<groupId>org.corpus-tools</groupId>
+	<artifactId>annis</artifactId>
 	<version>4.0.0-beta.5-SNAPSHOT</version>
-	<name>annis-gui</name>
+	<name>ANNIS user interface</name>
 	<packaging>jar</packaging>
 	<scm>
 		<connection>scm:git:https://github.com/korpling/ANNIS.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -563,6 +563,12 @@
 			<artifactId>toml4j</artifactId>
 			<version>0.7.2</version>
 		</dependency>
+		
+		<dependency>
+		  <groupId>org.tomlj</groupId>
+		  <artifactId>tomlj</artifactId>
+		  <version>1.0.0</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
@@ -77,7 +77,9 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
                         execPath = Optional.of("win32-x86-64/graphannis-webservice.exe");
                     }
                 } else {
-                    log.error("GraphANNIS can only be run on 64 bit operating systems!");
+                  log.error(
+                      "GraphANNIS can only be run on 64 bit operating systems (\"amd64\"), but this is reported as architecture {}!",
+                      SystemUtils.OS_ARCH);
                 }
 
                 if (execPath.isPresent()) {

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
@@ -68,7 +68,7 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
             try {
                 // Extract the bundled resource to a temporary file
                 Optional<String> execPath = Optional.empty();
-                if ("amd64".equals(SystemUtils.OS_ARCH)) {
+                if ("amd64".equals(SystemUtils.OS_ARCH) || "x86_64".equals(SystemUtils.OS_ARCH)) {
                     if (SystemUtils.IS_OS_LINUX) {
                         execPath = Optional.of("linux-x86-64/graphannis-webservice");
                     } else if (SystemUtils.IS_OS_MAC_OSX) {
@@ -78,7 +78,7 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
                     }
                 } else {
                   log.error(
-                      "GraphANNIS can only be run on 64 bit operating systems (\"amd64\"), but this is reported as architecture {}!",
+                      "GraphANNIS can only be run on 64 bit operating systems (\"amd64\" or \"x86_64\"), but this is reported as architecture {}!",
                       SystemUtils.OS_ARCH);
                 }
 

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
@@ -116,6 +116,9 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
   protected File getServiceConfig() throws IOException {
     TomlParseResult tomlConfig = Toml.parse(super.getServiceConfig().toPath());
     Map<String, Object> config = unpackToml(tomlConfig);
+    if (config == null) {
+      config = new LinkedHashMap<>();
+    }
 
     // Add it to the configuration
     Map<String, Object> tokenVerification = new LinkedHashMap<>();

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
@@ -66,10 +66,7 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
   @Autowired
   private Environment env;
 
-  private List<Object> unpackToml(TomlArray orig) {
-    if (orig == null) {
-      return null;
-    }
+  protected static List<Object> unpackToml(TomlArray orig) {
     ArrayList<Object> result = new ArrayList<>(orig.size());
 
     for (Object o : orig.toList()) {
@@ -87,11 +84,7 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
     return result;
   }
 
-  private Map<String, Object> unpackToml(TomlTable orig) {
-    if (orig == null) {
-      return null;
-    }
-
+  protected static Map<String, Object> unpackToml(TomlTable orig) {
     LinkedHashMap<String, Object> result = new LinkedHashMap<>();
 
     for (Map.Entry<String, Object> e : orig.toMap().entrySet()) {
@@ -116,9 +109,6 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
   protected File getServiceConfig() throws IOException {
     TomlParseResult tomlConfig = Toml.parse(super.getServiceConfig().toPath());
     Map<String, Object> config = unpackToml(tomlConfig);
-    if (config == null) {
-      config = new LinkedHashMap<>();
-    }
 
     // Add it to the configuration
     Map<String, Object> tokenVerification = new LinkedHashMap<>();

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
@@ -216,7 +216,7 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
     // Open the application in the browser
     String webURL = "http://localhost:" + serverPort;
     boolean isRunningHeadless =
-        Arrays.stream(env.getActiveProfiles()).anyMatch(profile -> "headless".equals(profile));
+        Arrays.stream(env.getActiveProfiles()).anyMatch("headless"::equals);
     Desktop desktop =
         !isRunningHeadless && Desktop.isDesktopSupported() ? Desktop.getDesktop() : null;
     if (desktop == null) {

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
@@ -2,7 +2,6 @@ package org.corpus_tools.annis.gui;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
-import com.moandjiezana.toml.Toml;
 import com.moandjiezana.toml.TomlWriter;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -16,6 +15,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -45,159 +45,205 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.stereotype.Component;
+import org.tomlj.Toml;
+import org.tomlj.TomlArray;
+import org.tomlj.TomlParseResult;
+import org.tomlj.TomlTable;
 
 @Component
 @Profile("desktop")
 public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused code)
 
-    private static final String USER_NAME = "desktop";
-    private static final Logger log = LoggerFactory.getLogger(ServiceStarterDesktop.class);
-    private final String secret = RandomStringUtils.randomAlphanumeric(50);
-    private Optional<UsernamePasswordAuthenticationToken> desktopUserCredentials = Optional.empty();
+  private static final String USER_NAME = "desktop";
+  private static final Logger log = LoggerFactory.getLogger(ServiceStarterDesktop.class);
+  private final String secret = RandomStringUtils.randomAlphanumeric(50);
+  private Optional<UsernamePasswordAuthenticationToken> desktopUserCredentials = Optional.empty();
 
 
-    @Value("${server.port}")
-    private String serverPort;
+  @Value("${server.port}")
+  private String serverPort;
 
-    @Autowired
-    private Environment env;
+  @Autowired
+  private Environment env;
 
-    /**
-     * Overwrite the existing configuration file and add a temporary user for the desktop.
-     */
-    @Override
-    protected File getServiceConfig() throws IOException {
-        Toml tomlConfig = new Toml().read(super.getServiceConfig());
-        Map<String, Object> config = tomlConfig.toMap();
+  private List<Object> unpackToml(TomlArray orig) {
+    if (orig == null) {
+      return null;
+    }
+    ArrayList<Object> result = new ArrayList<>(orig.size());
 
-        // Add it to the configuration
-        Map<String, Object> tokenVerification = new LinkedHashMap<>();
-        tokenVerification.put("type", "HS256");
-        tokenVerification.put("secret", this.secret);
-
-        // Add the new auth configuration (removing all existing settings in [auth])
-        Map<String, Object> auth = new HashMap<>();
-        auth.put("token_verification", tokenVerification);
-        config.put("auth", auth);
-
-
-        File temporaryFile = File.createTempFile("annis-service-config-desktop-", ".toml");
-        TomlWriter writer = new TomlWriter();
-        writer.write(config, temporaryFile);
-        return temporaryFile;
+    for (Object o : orig.toList()) {
+      if (o instanceof TomlArray) {
+        TomlArray tomlArray = (TomlArray) o;
+        result.add(unpackToml(tomlArray));
+      } else if (o instanceof TomlTable) {
+        TomlTable tomlTable = (TomlTable) o;
+        result.add(unpackToml(tomlTable));
+      } else {
+        result.add(o);
+      }
     }
 
-    private void showApplicationWindow(Desktop desktop) {
-        try {
-            UIManager.setLookAndFeel(new NimbusLookAndFeel());
-        } catch (UnsupportedLookAndFeelException ex) {
-            log.warn("Look and feel not supported", ex);
-        }
+    return result;
+  }
 
-
-        // Create a window where log messages and a link to the UI can be shown
-        // This also allows to exit the application when no terminal is shown.
-        JFrame mainFrame = new JFrame("ANNIS Desktop");
-        BorderLayout mainLayout = new BorderLayout();
-        mainFrame.getContentPane().setLayout(mainLayout);
-        mainFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-        mainFrame.setLocationByPlatform(true);
-
-
-        final String webURL = "http://localhost:" + serverPort;
-        JButton btLaunch = new JButton();
-
-        btLaunch.setMnemonic('u');
-        btLaunch.setForeground(Color.blue);
-        btLaunch.setText("<html><u>Open " + webURL + " in browser</u></html>");
-        btLaunch.setEnabled(true);
-        btLaunch.setName("btLaunch");
-        btLaunch.addActionListener((evt) -> {
-            try {
-                desktop.browse(new URI(webURL));
-            } catch (IOException | URISyntaxException ex) {
-                log.error("Could not open browser", ex);
-            }
-        });
-        btLaunch.setPreferredSize(new Dimension(300, 60));
-        mainFrame.getContentPane().add(btLaunch, BorderLayout.CENTER);
-
-        JButton btExit = new JButton("Exit");
-        btExit.addActionListener((evt) -> {
-            System.exit(0);
-        });
-        mainFrame.getContentPane().add(btExit, BorderLayout.PAGE_END);
-
-        mainFrame.pack();
-
-        // Set icon for window
-        Integer[] sizes = new Integer[] {192, 128, 64, 48, 32, 16, 14};
-        List<Image> allImages = new LinkedList<Image>();
-
-        for (int s : sizes) {
-            try {
-                BufferedImage imgIcon = ImageIO
-                        .read(ServiceStarterDesktop.class.getResource("logo/annis_" + s + ".png"));
-                allImages.add(imgIcon);
-            } catch (IOException ex) {
-                log.error(null, ex);
-            }
-        }
-        mainFrame.setIconImages(allImages);
-
-        mainFrame.setVisible(true);
+  private Map<String, Object> unpackToml(TomlTable orig) {
+    if (orig == null) {
+      return null;
     }
 
-    @Override
-    public void onApplicationEvent(ApplicationReadyEvent event) {
-        super.onApplicationEvent(event);
+    LinkedHashMap<String, Object> result = new LinkedHashMap<>();
 
-        List<String> roles = Arrays.asList("admin");
-        Instant issuedAt = Instant.now();
-        Instant expiresAt = Instant.now().plus(7l, ChronoUnit.DAYS);
+    for (Map.Entry<String, Object> e : orig.toMap().entrySet()) {
+      if(e.getValue() instanceof TomlArray) {
+        TomlArray tomlArray = (TomlArray) e.getValue();
+        result.put(e.getKey(), unpackToml(tomlArray));
+      } else if (e.getValue() instanceof TomlTable) {
+        TomlTable tomlTable = (TomlTable) e.getValue();
+        result.put(e.getKey(), unpackToml(tomlTable));
+      } else {
+        result.put(e.getKey(), e.getValue());
+      }
+    }
+    
+    return result;
+  }
 
-        // Use the secret to sign a new JWT token with admin rights
-        String signedToken = JWT.create().withSubject(USER_NAME)
-                .withClaim(SecurityConfiguration.ROLES_CLAIM, roles)
-                .withExpiresAt(Date.from(expiresAt)).withIssuedAt(Date.from(issuedAt))
-                .sign(Algorithm.HMAC256(this.secret));
+  /**
+   * Overwrite the existing configuration file and add a temporary user for the desktop.
+   */
+  @Override
+  protected File getServiceConfig() throws IOException {
+    TomlParseResult tomlConfig = Toml.parse(super.getServiceConfig().toPath());
+    Map<String, Object> config = unpackToml(tomlConfig);
 
-        // Create the needed information for to represent this token as OIDC token in Spring
-        // security
-        List<? extends GrantedAuthority> grantedAuthorities =
-                Arrays.asList(new SimpleGrantedAuthority("admin"));
-        LinkedHashMap<String, Object> claims = new LinkedHashMap<>();
-        claims.put(SecurityConfiguration.ROLES_CLAIM, roles);
-        claims.put("sub", USER_NAME);
-        OidcIdToken token = new OidcIdToken(signedToken, issuedAt, expiresAt, claims);
-        DefaultOidcUser user = new DefaultOidcUser(grantedAuthorities, token);
-        this.desktopUserCredentials = Optional
-                .of(new UsernamePasswordAuthenticationToken(user, signedToken, grantedAuthorities));
+    // Add it to the configuration
+    Map<String, Object> tokenVerification = new LinkedHashMap<>();
+    tokenVerification.put("type", "HS256");
+    tokenVerification.put("secret", this.secret);
 
-        // Open the application in the browser
-        String webURL = "http://localhost:" + serverPort;
-        boolean isRunningHeadless = Arrays.stream(env.getActiveProfiles())
-                .anyMatch(profile -> "headless".equals(profile));
-        Desktop desktop =
-                !isRunningHeadless && Desktop.isDesktopSupported() ? Desktop.getDesktop() : null;
-        if (desktop == null) {
-            log.warn(
-                    "ANNIS is running in desktop mode, but no desktop has been detected. You can open {} manually.",
-                    webURL);
-        } else {
-            showApplicationWindow(desktop);
-            log.info("Opening {} in browser", webURL);
-            try {
-                desktop.browse(new URI(webURL));
-            } catch (IOException | URISyntaxException ex) {
-                log.error("Could not open " + webURL + " in browser.", ex);
-            }
-        }
+    // Add the new auth configuration (removing all existing settings in [auth])
+    Map<String, Object> auth = new HashMap<>();
+    auth.put("token_verification", tokenVerification);
+    config.put("auth", auth);
+
+
+    File temporaryFile = File.createTempFile("annis-service-config-desktop-", ".toml");
+    TomlWriter writer = new TomlWriter();
+    writer.write(config, temporaryFile);
+    return temporaryFile;
+  }
+
+  private void showApplicationWindow(Desktop desktop) {
+    try {
+      UIManager.setLookAndFeel(new NimbusLookAndFeel());
+    } catch (UnsupportedLookAndFeelException ex) {
+      log.warn("Look and feel not supported", ex);
     }
 
-    @Override
-    public Optional<UsernamePasswordAuthenticationToken> getDesktopUserToken() {
-        return desktopUserCredentials;
+
+    // Create a window where log messages and a link to the UI can be shown
+    // This also allows to exit the application when no terminal is shown.
+    JFrame mainFrame = new JFrame("ANNIS Desktop");
+    BorderLayout mainLayout = new BorderLayout();
+    mainFrame.getContentPane().setLayout(mainLayout);
+    mainFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+    mainFrame.setLocationByPlatform(true);
+
+
+    final String webURL = "http://localhost:" + serverPort;
+    JButton btLaunch = new JButton();
+
+    btLaunch.setMnemonic('u');
+    btLaunch.setForeground(Color.blue);
+    btLaunch.setText("<html><u>Open " + webURL + " in browser</u></html>");
+    btLaunch.setEnabled(true);
+    btLaunch.setName("btLaunch");
+    btLaunch.addActionListener((evt) -> {
+      try {
+        desktop.browse(new URI(webURL));
+      } catch (IOException | URISyntaxException ex) {
+        log.error("Could not open browser", ex);
+      }
+    });
+    btLaunch.setPreferredSize(new Dimension(300, 60));
+    mainFrame.getContentPane().add(btLaunch, BorderLayout.CENTER);
+
+    JButton btExit = new JButton("Exit");
+    btExit.addActionListener((evt) -> {
+      System.exit(0);
+    });
+    mainFrame.getContentPane().add(btExit, BorderLayout.PAGE_END);
+
+    mainFrame.pack();
+
+    // Set icon for window
+    Integer[] sizes = new Integer[] {192, 128, 64, 48, 32, 16, 14};
+    List<Image> allImages = new LinkedList<Image>();
+
+    for (int s : sizes) {
+      try {
+        BufferedImage imgIcon =
+            ImageIO.read(ServiceStarterDesktop.class.getResource("logo/annis_" + s + ".png"));
+        allImages.add(imgIcon);
+      } catch (IOException ex) {
+        log.error(null, ex);
+      }
     }
+    mainFrame.setIconImages(allImages);
+
+    mainFrame.setVisible(true);
+  }
+
+  @Override
+  public void onApplicationEvent(ApplicationReadyEvent event) {
+    super.onApplicationEvent(event);
+
+    List<String> roles = Arrays.asList("admin");
+    Instant issuedAt = Instant.now();
+    Instant expiresAt = Instant.now().plus(7l, ChronoUnit.DAYS);
+
+    // Use the secret to sign a new JWT token with admin rights
+    String signedToken = JWT.create().withSubject(USER_NAME)
+        .withClaim(SecurityConfiguration.ROLES_CLAIM, roles).withExpiresAt(Date.from(expiresAt))
+        .withIssuedAt(Date.from(issuedAt)).sign(Algorithm.HMAC256(this.secret));
+
+    // Create the needed information for to represent this token as OIDC token in Spring
+    // security
+    List<? extends GrantedAuthority> grantedAuthorities =
+        Arrays.asList(new SimpleGrantedAuthority("admin"));
+    LinkedHashMap<String, Object> claims = new LinkedHashMap<>();
+    claims.put(SecurityConfiguration.ROLES_CLAIM, roles);
+    claims.put("sub", USER_NAME);
+    OidcIdToken token = new OidcIdToken(signedToken, issuedAt, expiresAt, claims);
+    DefaultOidcUser user = new DefaultOidcUser(grantedAuthorities, token);
+    this.desktopUserCredentials =
+        Optional.of(new UsernamePasswordAuthenticationToken(user, signedToken, grantedAuthorities));
+
+    // Open the application in the browser
+    String webURL = "http://localhost:" + serverPort;
+    boolean isRunningHeadless =
+        Arrays.stream(env.getActiveProfiles()).anyMatch(profile -> "headless".equals(profile));
+    Desktop desktop =
+        !isRunningHeadless && Desktop.isDesktopSupported() ? Desktop.getDesktop() : null;
+    if (desktop == null) {
+      log.warn(
+          "ANNIS is running in desktop mode, but no desktop has been detected. You can open {} manually.",
+          webURL);
+    } else {
+      showApplicationWindow(desktop);
+      log.info("Opening {} in browser", webURL);
+      try {
+        desktop.browse(new URI(webURL));
+      } catch (IOException | URISyntaxException ex) {
+        log.error("Could not open " + webURL + " in browser.", ex);
+      }
+    }
+  }
+
+  @Override
+  public Optional<UsernamePasswordAuthenticationToken> getDesktopUserToken() {
+    return desktopUserCredentials;
+  }
 
 }

--- a/src/test/java/org/corpus_tools/annis/gui/ServiceStarterDesktopTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/ServiceStarterDesktopTest.java
@@ -1,0 +1,35 @@
+package org.corpus_tools.annis.gui;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.tomlj.Toml;
+import org.tomlj.TomlParseResult;
+
+class ServiceStarterDesktopTest {
+
+
+  @Test
+  void testUnpackToml() {
+    TomlParseResult toml = Toml.parse("[main]\n" + "test =\"value\"\n" + "b = [42, 23]");
+    Map<String, Object> unpacked = ServiceStarterDesktop.unpackToml(toml);
+
+    assertEquals(1, unpacked.size());
+    assertTrue(unpacked.get("main") instanceof Map);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> main = (Map<String, Object>) unpacked.get("main");
+    assertEquals(2, main.size());
+
+    assertEquals("value", main.get("test"));
+    assertTrue(main.get("b") instanceof List);
+    @SuppressWarnings("unchecked")
+    List<Object> b = (List<Object>) main.get("b");
+    assertEquals(2, b.size());
+    assertEquals(42l, b.get(0));
+    assertEquals(23l, b.get(1));
+  }
+
+}

--- a/src/test/java/org/corpus_tools/annis/gui/ServiceStarterDesktopTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/ServiceStarterDesktopTest.java
@@ -3,6 +3,7 @@ package org.corpus_tools.annis.gui;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -14,14 +15,15 @@ class ServiceStarterDesktopTest {
 
   @Test
   void testUnpackToml() {
-    TomlParseResult toml = Toml.parse("[main]\n" + "test =\"value\"\n" + "b = [42, 23]");
+    TomlParseResult toml = Toml.parse(
+        "[main]\n" + "test =\"value\"\n" + "b = [42, 23]\n" + "nested_array = [[1,2]]");
     Map<String, Object> unpacked = ServiceStarterDesktop.unpackToml(toml);
 
     assertEquals(1, unpacked.size());
     assertTrue(unpacked.get("main") instanceof Map);
     @SuppressWarnings("unchecked")
     Map<String, Object> main = (Map<String, Object>) unpacked.get("main");
-    assertEquals(2, main.size());
+    assertEquals(3, main.size());
 
     assertEquals("value", main.get("test"));
     assertTrue(main.get("b") instanceof List);
@@ -30,6 +32,13 @@ class ServiceStarterDesktopTest {
     assertEquals(2, b.size());
     assertEquals(42l, b.get(0));
     assertEquals(23l, b.get(1));
+
+    assertTrue(main.get("nested_array") instanceof List);
+    @SuppressWarnings("unchecked")
+    List<Object> nestedArray = (List<Object>) main.get("nested_array");
+    assertEquals(1, nestedArray.size());
+    assertTrue(nestedArray.get(0) instanceof List);
+    assertEquals(Arrays.asList(1l, 2l), nestedArray.get(0));
   }
 
 }


### PR DESCRIPTION
This fixes issues in Windows with parsing paths that contain `\U` (like `C:\Users`) and are interpreted as Unicode escape.