### PR TITLE
Fix metadata display in document browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not discard dominance edge, when only the target node has an incoming unnamed incoming edge.
   For the GUM corpus with mixed dominance for syntax and RST trees, this caused some segments to
   have no connection to any token. (#696)
+- Fix display of document meta annotations in the document browser 
 
 ## [4.0.0-beta.6] - 2021-04-01
 

--- a/misc/import-test-corpora.sh
+++ b/misc/import-test-corpora.sh
@@ -3,7 +3,9 @@
 curl -L -o pcc2.zip http://corpus-tools.org/corpora/pcc2_relANNIS.zip
 curl -L -o dialog.zip https://corpus-tools.org/corpora/dialog.demo_relANNIS.zip
 curl -L -o aeschylus.zip https://corpus-tools.org/corpora/Aeschylus.Persae.L1-18_relAnnis.zip
+curl -L -o shenoute.zip https://corpus-tools.org/corpora/shenoute.a22_ANNIS.zip 
 mkdir -p  $HOME/.annis/v4/
 annis $HOME/.annis/v4/ -c "import pcc2.zip"
 annis $HOME/.annis/v4/ -c "import dialog.zip"
 annis $HOME/.annis/v4/ -c "import aeschylus.zip"
+annis $HOME/.annis/v4/ -c "import shenoute.zip"

--- a/src/main/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserTable.java
+++ b/src/main/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserTable.java
@@ -336,25 +336,29 @@ public class DocBrowserTable extends Table {
    * @return The a list of meta data. Can be empty but never null.
    */
   private Set<SMetaAnnotation> getDocMetaData(String document) {
-    // lookup up meta data in the cache
-    Map<String, Set<SMetaAnnotation>> cachedMetaMap =
+    // Check if the corpus already has a cached map
+    Map<String, Set<SMetaAnnotation>> metaDataMap =
         docMetaDataCache.get(docBrowserPanel.getCorpus());
 
-    if (cachedMetaMap == null) {
-      // get the metadata for the corpus
-      Map<String, Set<SMetaAnnotation>> metaDataMap = new HashMap<>();
-
-      // Search for the document node, map it to Salt and return the attached annotations
-      List<SMetaAnnotation> annos =
-          Helper.getMetaDataDoc(docBrowserPanel.getCorpus(), document, UI.getCurrent());
-      metaDataMap.put(document, Collections.unmodifiableSet(new LinkedHashSet<>(annos)));
-
+    if (metaDataMap == null) {
+      // Create a new cached map for this corpus
+      metaDataMap = new HashMap<>();
       docMetaDataCache.put(docBrowserPanel.getCorpus(), metaDataMap);
-      return metaDataMap.get(document);
-
-    } else {
-      return cachedMetaMap.get(document);
     }
+
+    // Check if the cached map for this corpus already contains this document and directly return if when found
+    Set<SMetaAnnotation> metaAnnos = metaDataMap.get(document);
+    if (metaAnnos != null) {
+      return metaAnnos;
+    }
+
+    // Retrieve the meta data annotations as list
+    List<SMetaAnnotation> annos =
+        Helper.getMetaDataDoc(docBrowserPanel.getCorpus(), document, UI.getCurrent());
+    // Cache the documentation annotations for later use and return them
+    metaAnnos = Collections.unmodifiableSet(new LinkedHashSet<>(annos));
+    metaDataMap.put(document, metaAnnos);
+    return metaAnnos;
   }
 
   public void setContainerFilter(Filter filter) {

--- a/src/main/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserTable.java
+++ b/src/main/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserTable.java
@@ -390,14 +390,13 @@ public class DocBrowserTable extends Table {
       String doc = d.getName();
       String docId = d.getId();
 
-      // reverse path and delete the brackets and set a new separator:
-      // corpus > ... > subcorpus > document
       List<String> pathList = Helper.getCorpusPath(d.getId());
       if (pathList == null) {
         pathList = new LinkedList<>();
       }
 
-      Collections.reverse(pathList);
+      // Set a new separator:
+      // corpus > ... > subcorpus > document
       String path = StringUtils.join(pathList, " > ");
 
       // use corpus path for row id, since it should be unique by annis db schema

--- a/src/test/java/org/corpus_tools/annis/gui/CorpusBrowserPanelTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/CorpusBrowserPanelTest.java
@@ -19,9 +19,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.corpus_tools.annis.gui.AnnisUI;
-import org.corpus_tools.annis.gui.CorpusBrowserPanel;
-import org.corpus_tools.annis.gui.ExampleTable;
 import org.corpus_tools.annis.gui.beans.CorpusBrowserEntry;
 import org.corpus_tools.annis.gui.controlpanel.CorpusListPanel;
 import org.junit.jupiter.api.AfterEach;
@@ -53,8 +50,6 @@ class CorpusBrowserPanelTest {
     ui = beanFactory.getBean(AnnisUI.class);
 
     MockVaadin.setup(() -> ui);
-
-
   }
 
   @AfterEach

--- a/src/test/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserPanelTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserPanelTest.java
@@ -92,4 +92,17 @@ class DocBrowserPanelTest {
     assertEquals("shenoute.a22 > a22.ZC301-308", ids.get(3));
   }
 
+  @Test
+  void testMetadata() throws Exception {
+    openDocBrowser("shenoute.a22");
+
+    DocBrowserTable table = _get(DocBrowserTable.class);
+
+    assertEquals("MONB.YA", table.getContainerProperty("shenoute.a22 > a22.YA421-428", "msName"));
+    assertEquals("MONB.YA", table.getContainerProperty("shenoute.a22 > a22.YA517-518", "msName"));
+
+    assertEquals("MONB.YB", table.getContainerProperty("shenoute.a22 > a22.YB307-320", "msName"));
+    assertEquals("MONB.ZC", table.getContainerProperty("shenoute.a22 > a22.ZC301-308", "msName"));
+  }
+
 }

--- a/src/test/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserPanelTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserPanelTest.java
@@ -10,6 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.github.mvysny.kaributesting.v8.MockVaadin;
 import com.vaadin.spring.internal.UIScopeImpl;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.corpus_tools.annis.gui.AnnisUI;
 import org.corpus_tools.annis.gui.SingletonBeanStoreRetrievalStrategy;
 import org.junit.jupiter.api.AfterEach;
@@ -45,9 +47,8 @@ class DocBrowserPanelTest {
     MockVaadin.tearDown();
   }
 
-  @Test
-  void testCorpusPathListed() throws Exception {
-    ui.getSearchView().getDocBrowserController().openDocBrowser("pcc2");
+  private void openDocBrowser(String corpusName) throws Exception {
+    ui.getSearchView().getDocBrowserController().openDocBrowser(corpusName);
     // Panel should be immediately loaded
     DocBrowserPanel panel = _get(DocBrowserPanel.class);
     assertNotNull(panel);
@@ -57,12 +58,38 @@ class DocBrowserPanelTest {
       return !_find(DocBrowserTable.class).isEmpty();
     }, () -> "Document browser table did not appear");
 
+  }
+
+  @Test
+  void testCorpusPathListed() throws Exception {
+
+    openDocBrowser("pcc2");
+
     DocBrowserTable table = _get(DocBrowserTable.class);
     Collection<?> ids = table.getItemIds();
     assertEquals(2, ids.size());
 
     assertTrue(ids.contains("pcc2 > 11299"));
     assertTrue(ids.contains("pcc2 > 4282"));
+  }
+
+  @Test
+  void testDocumentOrder() throws Exception {
+    openDocBrowser("shenoute.a22");
+
+    DocBrowserTable table = _get(DocBrowserTable.class);
+
+    // Test order of entries, which is explicitly given in the document_browser.json of the corpus
+    // (Ordering by title, ascending)
+    List<String> ids =
+        table.getItemIds().stream().map(o -> o.toString()).collect(Collectors.toList());
+
+    assertEquals(4, ids.size());
+
+    assertEquals("shenoute.a22 > a22.YA421-428", ids.get(0));
+    assertEquals("shenoute.a22 > a22.YA517-518", ids.get(1));
+    assertEquals("shenoute.a22 > a22.YB307-320", ids.get(2));
+    assertEquals("shenoute.a22 > a22.ZC301-308", ids.get(3));
   }
 
 }

--- a/src/test/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserPanelTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserPanelTest.java
@@ -98,11 +98,15 @@ class DocBrowserPanelTest {
 
     DocBrowserTable table = _get(DocBrowserTable.class);
 
-    assertEquals("MONB.YA", table.getContainerProperty("shenoute.a22 > a22.YA421-428", "msName"));
-    assertEquals("MONB.YA", table.getContainerProperty("shenoute.a22 > a22.YA517-518", "msName"));
+    assertEquals("MONB.YA",
+        table.getContainerProperty("shenoute.a22 > a22.YA421-428", "msName").getValue());
+    assertEquals("MONB.YA",
+        table.getContainerProperty("shenoute.a22 > a22.YA517-518", "msName").getValue());
 
-    assertEquals("MONB.YB", table.getContainerProperty("shenoute.a22 > a22.YB307-320", "msName"));
-    assertEquals("MONB.ZC", table.getContainerProperty("shenoute.a22 > a22.ZC301-308", "msName"));
+    assertEquals("MONB.YB",
+        table.getContainerProperty("shenoute.a22 > a22.YB307-320", "msName").getValue());
+    assertEquals("MONB.ZC",
+        table.getContainerProperty("shenoute.a22 > a22.ZC301-308", "msName").getValue());
   }
 
 }

--- a/src/test/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserPanelTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserPanelTest.java
@@ -1,0 +1,68 @@
+package org.corpus_tools.annis.gui.docbrowser;
+
+import static com.github.mvysny.kaributesting.v8.LocatorJ._find;
+import static com.github.mvysny.kaributesting.v8.LocatorJ._get;
+import static org.corpus_tools.annis.gui.TestHelper.awaitCondition;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.mvysny.kaributesting.v8.MockVaadin;
+import com.vaadin.spring.internal.UIScopeImpl;
+import java.util.Collection;
+import org.corpus_tools.annis.gui.AnnisUI;
+import org.corpus_tools.annis.gui.SingletonBeanStoreRetrievalStrategy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+@SpringBootTest
+@ActiveProfiles({"desktop", "test", "headless"})
+@WebAppConfiguration
+class DocBrowserPanelTest {
+
+  @Autowired
+  private BeanFactory beanFactory;
+
+  AnnisUI ui;
+
+
+  @BeforeEach
+  public void setup() throws Exception {
+    UIScopeImpl.setBeanStoreRetrievalStrategy(new SingletonBeanStoreRetrievalStrategy());
+    ui = beanFactory.getBean(AnnisUI.class);
+
+    MockVaadin.setup(() -> ui);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    MockVaadin.tearDown();
+  }
+
+  @Test
+  void testCorpusPathListed() throws Exception {
+    ui.getSearchView().getDocBrowserController().openDocBrowser("pcc2");
+    // Panel should be immediately loaded
+    DocBrowserPanel panel = _get(DocBrowserPanel.class);
+    assertNotNull(panel);
+
+    // Wait for the actual document table to appear
+    awaitCondition(30, () -> {
+      return !_find(DocBrowserTable.class).isEmpty();
+    }, () -> "Document browser table did not appear");
+
+    DocBrowserTable table = _get(DocBrowserTable.class);
+    Collection<?> ids = table.getItemIds();
+    assertEquals(2, ids.size());
+
+    assertTrue(ids.contains("pcc2 > 11299"));
+    assertTrue(ids.contains("pcc2 > 4282"));
+  }
+
+}


### PR DESCRIPTION
Currently, the shown meta data fields in the document browser table are always "n/a"