### PR TITLE
Show warning instead of crash when "Desktop.browse" is not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   For the GUM corpus with mixed dominance for syntax and RST trees, this caused some segments to
   have no connection to any token. (#696)
 - Fix display of document meta annotations in the document browser 
+- Desktop UI aborted execution on KDE when trying to open the browser (#702)
 
 ## [4.0.0-beta.6] - 2021-04-01
 

--- a/pom.xml
+++ b/pom.xml
@@ -436,6 +436,12 @@
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-crypto</artifactId>
 		</dependency>
+		
+		<dependency>
+		  <groupId>com.github.jjYBdx4IL.utils</groupId>
+		  <artifactId>swing-utils</artifactId>
+		  <version>1.0</version>
+		</dependency>
 
 
 		<dependency>

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
@@ -233,7 +233,7 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
       } catch(UnsupportedOperationException ex) {
     	  log.warn(
     	          "Opening the browser is unsupported on this platform. "
-    	          + "Please open {} in your browser manually manually.",
+    	          + "Please open {} in your browser manually.",
     	          webURL);
       }
     }

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
@@ -2,7 +2,6 @@ package org.corpus_tools.annis.gui;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
-import com.google.common.base.Objects;
 import com.moandjiezana.toml.TomlWriter;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -56,190 +55,194 @@ import org.tomlj.TomlTable;
 @Profile("desktop")
 public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused code)
 
-	private static final String USER_NAME = "desktop";
-	private static final Logger log = LoggerFactory.getLogger(ServiceStarterDesktop.class);
-	private final String secret = RandomStringUtils.randomAlphanumeric(50);
-	private Optional<UsernamePasswordAuthenticationToken> desktopUserCredentials = Optional.empty();
+  private static final String USER_NAME = "desktop";
+  private static final Logger log = LoggerFactory.getLogger(ServiceStarterDesktop.class);
+  private final String secret = RandomStringUtils.randomAlphanumeric(50);
+  private Optional<UsernamePasswordAuthenticationToken> desktopUserCredentials = Optional.empty();
 
-	@Value("${server.port}")
-	private String serverPort;
+  @Value("${server.port}")
+  private String serverPort;
 
-	@Autowired
-	private Environment env;
+  @Autowired
+  private Environment env;
 
-	protected static List<Object> unpackToml(TomlArray orig) {
-		ArrayList<Object> result = new ArrayList<>(orig.size());
+  protected static List<Object> unpackToml(TomlArray orig) {
+    ArrayList<Object> result = new ArrayList<>(orig.size());
 
-		for (Object o : orig.toList()) {
-			if (o instanceof TomlArray) {
-				TomlArray tomlArray = (TomlArray) o;
-				result.add(unpackToml(tomlArray));
-			} else if (o instanceof TomlTable) {
-				TomlTable tomlTable = (TomlTable) o;
-				result.add(unpackToml(tomlTable));
-			} else {
-				result.add(o);
-			}
-		}
+    for (Object o : orig.toList()) {
+      if (o instanceof TomlArray) {
+        TomlArray tomlArray = (TomlArray) o;
+        result.add(unpackToml(tomlArray));
+      } else if (o instanceof TomlTable) {
+        TomlTable tomlTable = (TomlTable) o;
+        result.add(unpackToml(tomlTable));
+      } else {
+        result.add(o);
+      }
+    }
 
-		return result;
-	}
+    return result;
+  }
 
-	protected static Map<String, Object> unpackToml(TomlTable orig) {
-		LinkedHashMap<String, Object> result = new LinkedHashMap<>();
+  protected static Map<String, Object> unpackToml(TomlTable orig) {
+    LinkedHashMap<String, Object> result = new LinkedHashMap<>();
 
-		for (Map.Entry<String, Object> e : orig.toMap().entrySet()) {
-			if (e.getValue() instanceof TomlArray) {
-				TomlArray tomlArray = (TomlArray) e.getValue();
-				result.put(e.getKey(), unpackToml(tomlArray));
-			} else if (e.getValue() instanceof TomlTable) {
-				TomlTable tomlTable = (TomlTable) e.getValue();
-				result.put(e.getKey(), unpackToml(tomlTable));
-			} else {
-				result.put(e.getKey(), e.getValue());
-			}
-		}
+    for (Map.Entry<String, Object> e : orig.toMap().entrySet()) {
+      if (e.getValue() instanceof TomlArray) {
+        TomlArray tomlArray = (TomlArray) e.getValue();
+        result.put(e.getKey(), unpackToml(tomlArray));
+      } else if (e.getValue() instanceof TomlTable) {
+        TomlTable tomlTable = (TomlTable) e.getValue();
+        result.put(e.getKey(), unpackToml(tomlTable));
+      } else {
+        result.put(e.getKey(), e.getValue());
+      }
+    }
 
-		return result;
-	}
+    return result;
+  }
 
-	/**
-	 * Overwrite the existing configuration file and add a temporary user for the
-	 * desktop.
-	 */
-	@Override
-	protected File getServiceConfig() throws IOException {
-		TomlParseResult tomlConfig = Toml.parse(super.getServiceConfig().toPath());
-		Map<String, Object> config = unpackToml(tomlConfig);
+  /**
+   * Overwrite the existing configuration file and add a temporary user for the desktop.
+   */
+  @Override
+  protected File getServiceConfig() throws IOException {
+    TomlParseResult tomlConfig = Toml.parse(super.getServiceConfig().toPath());
+    Map<String, Object> config = unpackToml(tomlConfig);
 
-		// Add it to the configuration
-		Map<String, Object> tokenVerification = new LinkedHashMap<>();
-		tokenVerification.put("type", "HS256");
-		tokenVerification.put("secret", this.secret);
+    // Add it to the configuration
+    Map<String, Object> tokenVerification = new LinkedHashMap<>();
+    tokenVerification.put("type", "HS256");
+    tokenVerification.put("secret", this.secret);
 
-		// Add the new auth configuration (removing all existing settings in [auth])
-		Map<String, Object> auth = new HashMap<>();
-		auth.put("token_verification", tokenVerification);
-		config.put("auth", auth);
+    // Add the new auth configuration (removing all existing settings in [auth])
+    Map<String, Object> auth = new HashMap<>();
+    auth.put("token_verification", tokenVerification);
+    config.put("auth", auth);
 
-		File temporaryFile = File.createTempFile("annis-service-config-desktop-", ".toml");
-		TomlWriter writer = new TomlWriter();
-		writer.write(config, temporaryFile);
-		return temporaryFile;
-	}
+    File temporaryFile = File.createTempFile("annis-service-config-desktop-", ".toml");
+    TomlWriter writer = new TomlWriter();
+    writer.write(config, temporaryFile);
+    return temporaryFile;
+  }
 
-	private void showApplicationWindow(Desktop desktop) {
-		try {
-			UIManager.setLookAndFeel(new NimbusLookAndFeel());
-		} catch (UnsupportedLookAndFeelException ex) {
-			log.warn("Look and feel not supported", ex);
-		}
+  private void showApplicationWindow() {
+    try {
+      UIManager.setLookAndFeel(new NimbusLookAndFeel());
+    } catch (UnsupportedLookAndFeelException ex) {
+      log.warn("Look and feel not supported", ex);
+    }
 
-		// Create a window where log messages and a link to the UI can be shown
-		// This also allows to exit the application when no terminal is shown.
-		JFrame mainFrame = new JFrame("ANNIS Desktop");
-		BorderLayout mainLayout = new BorderLayout();
-		mainFrame.getContentPane().setLayout(mainLayout);
-		mainFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-		mainFrame.setLocationByPlatform(true);
+    // Create a window where log messages and a link to the UI can be shown
+    // This also allows to exit the application when no terminal is shown.
+    JFrame mainFrame = new JFrame("ANNIS Desktop");
+    BorderLayout mainLayout = new BorderLayout();
+    mainFrame.getContentPane().setLayout(mainLayout);
+    mainFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+    mainFrame.setLocationByPlatform(true);
 
-		final String webURL = "http://localhost:" + serverPort;
-		JButton btLaunch = new JButton();
+    final String webURL = "http://localhost:" + serverPort;
+    JButton btLaunch = new JButton();
 
-		btLaunch.setMnemonic('u');
-		btLaunch.setForeground(Color.blue);
-		btLaunch.setText("<html><u>Open " + webURL + " in browser</u></html>");
-		btLaunch.setEnabled(true);
-		btLaunch.setName("btLaunch");
-		btLaunch.addActionListener(evt -> openBrowser(webURL));
-		btLaunch.setPreferredSize(new Dimension(300, 60));
-		mainFrame.getContentPane().add(btLaunch, BorderLayout.CENTER);
+    btLaunch.setMnemonic('u');
+    btLaunch.setForeground(Color.blue);
+    btLaunch.setText("<html><u>Open " + webURL + " in browser</u></html>");
+    btLaunch.setEnabled(true);
+    btLaunch.setName("btLaunch");
+    btLaunch.addActionListener(evt -> openBrowser(webURL));
+    btLaunch.setPreferredSize(new Dimension(300, 60));
+    mainFrame.getContentPane().add(btLaunch, BorderLayout.CENTER);
 
-		JButton btExit = new JButton("Exit");
-		btExit.addActionListener((evt) -> {
-			System.exit(0);
-		});
-		mainFrame.getContentPane().add(btExit, BorderLayout.PAGE_END);
+    JButton btExit = new JButton("Exit");
+    btExit.addActionListener((evt) -> {
+      System.exit(0);
+    });
+    mainFrame.getContentPane().add(btExit, BorderLayout.PAGE_END);
 
-		mainFrame.pack();
+    mainFrame.pack();
 
-		// Set icon for window
-		Integer[] sizes = new Integer[] { 192, 128, 64, 48, 32, 16, 14 };
-		List<Image> allImages = new LinkedList<Image>();
+    // Set icon for window
+    Integer[] sizes = new Integer[] {192, 128, 64, 48, 32, 16, 14};
+    List<Image> allImages = new LinkedList<Image>();
 
-		for (int s : sizes) {
-			try {
-				BufferedImage imgIcon = ImageIO
-						.read(ServiceStarterDesktop.class.getResource("logo/annis_" + s + ".png"));
-				allImages.add(imgIcon);
-			} catch (IOException ex) {
-				log.error(null, ex);
-			}
-		}
-		mainFrame.setIconImages(allImages);
+    for (int s : sizes) {
+      try {
+        BufferedImage imgIcon =
+            ImageIO.read(ServiceStarterDesktop.class.getResource("logo/annis_" + s + ".png"));
+        allImages.add(imgIcon);
+      } catch (IOException ex) {
+        log.error(null, ex);
+      }
+    }
+    mainFrame.setIconImages(allImages);
 
-		mainFrame.setVisible(true);
-	}
+    mainFrame.setVisible(true);
+  }
 
-	@Override
-	public void onApplicationEvent(ApplicationReadyEvent event) {
-		super.onApplicationEvent(event);
+  @Override
+  public void onApplicationEvent(ApplicationReadyEvent event) {
+    super.onApplicationEvent(event);
 
-		List<String> roles = Arrays.asList("admin");
-		Instant issuedAt = Instant.now();
-		Instant expiresAt = Instant.now().plus(7l, ChronoUnit.DAYS);
+    List<String> roles = Arrays.asList("admin");
+    Instant issuedAt = Instant.now();
+    Instant expiresAt = Instant.now().plus(7l, ChronoUnit.DAYS);
 
-		// Use the secret to sign a new JWT token with admin rights
-		String signedToken = JWT.create().withSubject(USER_NAME).withClaim(SecurityConfiguration.ROLES_CLAIM, roles)
-				.withExpiresAt(Date.from(expiresAt)).withIssuedAt(Date.from(issuedAt))
-				.sign(Algorithm.HMAC256(this.secret));
+    // Use the secret to sign a new JWT token with admin rights
+    String signedToken = JWT.create().withSubject(USER_NAME)
+        .withClaim(SecurityConfiguration.ROLES_CLAIM, roles).withExpiresAt(Date.from(expiresAt))
+        .withIssuedAt(Date.from(issuedAt)).sign(Algorithm.HMAC256(this.secret));
 
-		// Create the needed information for to represent this token as OIDC token in
-		// Spring
-		// security
-		List<? extends GrantedAuthority> grantedAuthorities = Arrays.asList(new SimpleGrantedAuthority("admin"));
-		LinkedHashMap<String, Object> claims = new LinkedHashMap<>();
-		claims.put(SecurityConfiguration.ROLES_CLAIM, roles);
-		claims.put("sub", USER_NAME);
-		OidcIdToken token = new OidcIdToken(signedToken, issuedAt, expiresAt, claims);
-		DefaultOidcUser user = new DefaultOidcUser(grantedAuthorities, token);
-		this.desktopUserCredentials = Optional
-				.of(new UsernamePasswordAuthenticationToken(user, signedToken, grantedAuthorities));
+    // Create the needed information for to represent this token as OIDC token in
+    // Spring
+    // security
+    List<? extends GrantedAuthority> grantedAuthorities =
+        Arrays.asList(new SimpleGrantedAuthority("admin"));
+    LinkedHashMap<String, Object> claims = new LinkedHashMap<>();
+    claims.put(SecurityConfiguration.ROLES_CLAIM, roles);
+    claims.put("sub", USER_NAME);
+    OidcIdToken token = new OidcIdToken(signedToken, issuedAt, expiresAt, claims);
+    DefaultOidcUser user = new DefaultOidcUser(grantedAuthorities, token);
+    this.desktopUserCredentials =
+        Optional.of(new UsernamePasswordAuthenticationToken(user, signedToken, grantedAuthorities));
 
-		// Open the application in the browser
-		String webURL = "http://localhost:" + serverPort;
-		boolean isRunningHeadless = Arrays.stream(env.getActiveProfiles()).anyMatch("headless"::equals);
-		Desktop desktop = !isRunningHeadless && Desktop.isDesktopSupported() ? Desktop.getDesktop() : null;
-		if (desktop == null) {
-			log.warn("ANNIS is running in desktop mode, but no desktop has been detected. You can open {} manually.",
-					webURL);
-		} else {
-			showApplicationWindow(desktop);
-			openBrowser(webURL);
-		}
-	}
+    // Open the application in the browser
+    String webURL = "http://localhost:" + serverPort;
+    boolean isRunningHeadless = Arrays.stream(env.getActiveProfiles()).anyMatch("headless"::equals);
+    Desktop desktop =
+        !isRunningHeadless && Desktop.isDesktopSupported() ? Desktop.getDesktop() : null;
+    if (desktop == null) {
+      log.warn(
+          "ANNIS is running in desktop mode, but no desktop has been detected. You can open {} manually.",
+          webURL);
+    } else {
+      showApplicationWindow();
+      openBrowser(webURL);
+    }
+  }
 
-	private void openBrowser(String webURL) {
-		log.info("Opening {} in browser", webURL);
-		boolean supported = false;
-		try {
-			supported = com.github.jjYBdx4IL.utils.awt.Desktop.browse(new URI(webURL));
-		} catch (URISyntaxException ex) {
-			log.error("Could not open " + webURL + " in browser.", ex);
-		} catch (UnsupportedOperationException ex) {
-			supported = false;
-		}
-		if (!supported) {
-			log.warn("Opening the browser is unsupported on this platform. "
-					+ "Please open {} in your browser manually.", webURL);
-			JOptionPane.showMessageDialog(null, "Cannot open the browser automatically. You can manually browse to "
-					+ webURL + " top open the ANNIS interface.");
-		}
-	}
+  private void openBrowser(String webURL) {
+    log.info("Opening {} in browser", webURL);
+    boolean supported = true;
+    try {
+      supported = com.github.jjYBdx4IL.utils.awt.Desktop.browse(new URI(webURL));
+    } catch (URISyntaxException ex) {
+      log.error("Could not open " + webURL + " in browser.", ex);
+      supported = false;
+    } catch (UnsupportedOperationException ex) {
+      supported = false;
+    }
+    if (!supported) {
+      log.warn("Opening the browser is unsupported on this platform. "
+          + "Please open {} in your browser manually.", webURL);
+      JOptionPane.showMessageDialog(null,
+          "Cannot open the browser automatically. You can manually browse to " + webURL
+              + " top open the ANNIS interface.");
+    }
+  }
 
-	@Override
-	public Optional<UsernamePasswordAuthenticationToken> getDesktopUserToken() {
-		return desktopUserCredentials;
-	}
+  @Override
+  public Optional<UsernamePasswordAuthenticationToken> getDesktopUserToken() {
+    return desktopUserCredentials;
+  }
 
 }

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
@@ -152,13 +152,7 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
     btLaunch.setText("<html><u>Open " + webURL + " in browser</u></html>");
     btLaunch.setEnabled(true);
     btLaunch.setName("btLaunch");
-    btLaunch.addActionListener((evt) -> {
-      try {
-        desktop.browse(new URI(webURL));
-      } catch (IOException | URISyntaxException ex) {
-        log.error("Could not open browser", ex);
-      }
-    });
+    btLaunch.addActionListener(evt -> openBrowser(desktop, webURL));
     btLaunch.setPreferredSize(new Dimension(300, 60));
     mainFrame.getContentPane().add(btLaunch, BorderLayout.CENTER);
 
@@ -225,7 +219,12 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
           webURL);
     } else {
       showApplicationWindow(desktop);
-      log.info("Opening {} in browser", webURL);
+      openBrowser(desktop, webURL);
+    }
+  }
+  
+  private void openBrowser(Desktop desktop, String webURL) {
+	  log.info("Opening {} in browser", webURL);
       try {
         desktop.browse(new URI(webURL));
       } catch (IOException | URISyntaxException ex) {
@@ -236,7 +235,6 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
     	          + "Please open {} in your browser manually.",
     	          webURL);
       }
-    }
   }
 
   @Override

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
@@ -230,6 +230,11 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
         desktop.browse(new URI(webURL));
       } catch (IOException | URISyntaxException ex) {
         log.error("Could not open " + webURL + " in browser.", ex);
+      } catch(UnsupportedOperationException ex) {
+    	  log.warn(
+    	          "Opening the browser is unsupported on this platform. "
+    	          + "Please open {} in your browser manually manually.",
+    	          webURL);
       }
     }
   }


### PR DESCRIPTION
This fixes #702 for KDE and should allow to at least open the main window on platforms where opening the browser fails