### PR TITLE
Automatically create release on tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 on: 
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - v*
 name: Deploy ANNIS
 jobs:
   deploy_release_binaries:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,6 @@ jobs:
               target/annis-*-desktop.jar
               annis-*-server.jar
             body: ${{ steps.extract-release-notes.outputs.release_notes }}
-            draft: true
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   deploy_documentation:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,10 +20,17 @@ jobs:
           run: mvn clean install
         - name: Build desktop binary
           run: mvn -Pdesktop install
+        - name: Extract release notes
+          id: extract-release-notes
+          uses: ffurrer2/extract-release-notes@v1
         - name: Release assets on GitHub
-          uses: alexellis/upload-assets@0.3.0
+          uses: softprops/action-gh-release@v0.1.12
           with:
-            asset_paths: '["./target/annis-*-server.jar", "./target/annis-*-desktop.jar"]'
+            files: |
+              target/annis-*-desktop.jar
+              annis-*-server.jar
+            body: ${{ steps.extract-release-notes.outputs.release_notes }}
+            draft: true
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   deploy_documentation:

--- a/docs/developer-guide/src/release.md
+++ b/docs/developer-guide/src/release.md
@@ -7,11 +7,9 @@ Otherwise the documentation can't be created.
 
 1. Check the changelog (`CHANGELOG.md`): note the last release version number and which kind of changes have been made since the last release.
    Determine if this is a major, minor or patch release according to [semantic versioning](https://semver.org/). 
-2. Release the **source code** using Maven.  The command will ask you for the new version number use the most appropriate with respect to the previous version number and the changes made.
+2. **Create a release** using Maven.  The command will ask you for the new version number use the most appropriate with respect to the previous version number and the changes made.
 ```
 mvn release:clean release:prepare release:perform
 ```
 This will update versions, the changelog, our citation file (`CITATION.cff`) and the contents of the `THIRD-PARTY` folder.
-
-3. Create a new **release on GitHub** including the changelog. The release binaries and a new version of the User and Developer Guide will be deployed by the GitHub Actions CI.
-
+An GitHub action will automatically create a release on the GitHub platform which includes the binary assets.


### PR DESCRIPTION
Instead of appending files to an existing release, we just automatically release when there is a new version-tag.