### PR TITLE
Integration with corpus-tools.org

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
           run: mvn -Pdesktop install
         - name: Extract release notes
           id: extract-release-notes
-          uses: ffurrer2/extract-release-notes@v1
+          uses: ffurrer2/extract-release-notes@v1.9.0
         - name: Release assets on GitHub
           id: create-release
           uses: softprops/action-gh-release@v0.1.12
@@ -39,7 +39,7 @@ jobs:
             repository: corpus-tools/corpus-tools.github.io
             token: ${{ secrets.CORPUS_TOOLS_TOKEN}}
             event-type: annis-release
-            client-payload: '{"version": "${{ steps.create-release.outputs.id }}"}'
+            client-payload: '{"version": "${{ steps.create-release.outputs.id }}", "release_notes": "${{ steps.extract-release-notes.outputs.release_notes }}"}'
   deploy_documentation:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
Trigger a repository dispatch for GitHub actions of the corpus-tools.org gh-pages repo on each release.
This allows to automatically link to the latest released version instead of changing this manuall everytime.
By adding the release notes, it is also possible to give some information about what changed compared to last time the user accessed the download page.