### PR TITLE
Enforce upgrade of (unused) log4j dependency to 2.15.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Enforce upgrade of (unused) log4j dependency to 2.15.0.
+  While we do have log4j in our classpath, Spring is not configured per default
+  to actually use log4j for debugging and thus ANNIS should be unaffected by
+  CVE-2021-44228 (see https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot). 
+  But it is better safe to than to be sorry, so we force Spring to use the fixed 
+  log4j version.
+
+
 ## [4.6.0] - 2021-12-08
 
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,14 @@
 		<swagger-core-version>1.5.24</swagger-core-version>
 		<gson-fire-version>1.8.4</gson-fire-version>
 		<kotlin.version>1.4.0</kotlin.version>
+		<!-- 
+		This can be removed as soon as Spring Boot 2.5.8 is released. While
+		we do have log4j in our classpath, Spring is not configured per default
+		to actually use log4j for debugging and thus ANNIS should be unaffected by
+		CVE-2021-44228 (see https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot). 
+		But it is better safe to than to be sorry, so we enforce the fixed log4j version here. 		 
+		  -->
+		<log4j2.version>2.15.0</log4j2.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
While we do have log4j in our classpath, Spring is not configured per default
to actually use log4j for debugging and thus ANNIS should be unaffected by
CVE-2021-44228 (see https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot).
But it is better safe to than to be sorry, so we enforce the fixed log4j version here.