### PR TITLE
Upgrading Spring boot dependency to 2.5.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Mitigate against security issue [CVE-2022-22965
+  ](https://tanzu.vmware.com/security/cve-2022-22965) by upgrading Spring boot
+  dependency to 2.5.12 See
+  <https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement>
+  for for information.
+
 ## [4.6.4] - 2022-04-01
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.2</version>
+		<version>2.5.12</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
@@ -44,14 +44,6 @@
 		<swagger-core-version>1.5.24</swagger-core-version>
 		<gson-fire-version>1.8.4</gson-fire-version>
 		<kotlin.version>1.4.0</kotlin.version>
-		<!-- 
-		This can be removed as soon as Spring Boot 2.5.8 is released. While
-		we do have log4j in our classpath, Spring is not configured per default
-		to actually use log4j for debugging and thus ANNIS should be unaffected by
-		CVE-2021-44228 (see https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot). 
-		But it is better safe to than to be sorry, so we enforce the fixed log4j version here. 		 
-		  -->
-		<log4j2.version>2.15.0</log4j2.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
Mitigate against security issue [CVE-2022-22965](https://tanzu.vmware.com/security/cve-2022-22965) by upgrading Spring boot dependency to 2.5.12

See <https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement> for for information.