### PR TITLE
Subcorpus metadata display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Show corpus metadata with corpus hits and not only the document metadata (#768)
+
 ## [4.6.7] - 2022-05-12
 
 ### Fixed

--- a/src/main/java/org/corpus_tools/annis/gui/Helper.java
+++ b/src/main/java/org/corpus_tools/annis/gui/Helper.java
@@ -652,11 +652,10 @@ public class Helper {
    * @param toplevelCorpusName Specifies the the toplevel corpus
    * @param documentName Specifies the document or leave empty if only the corpus meta data should
    *        be fetched.
-   * @return Returns also the metada of the all parent corpora. There must be at least one of them.
+   * @return Returns a corpus graph that contains the meta data as (sub-) corpus annotation.
    */
-  public static List<SMetaAnnotation> getMetaData(final String toplevelCorpusName,
+  public static SCorpusGraph getMetaData(final String toplevelCorpusName,
       final Optional<String> documentName, final UI ui) {
-    final List<SMetaAnnotation> result = new ArrayList<>();
     final SearchApi api = new SearchApi(Helper.getClient(ui));
 
     try {
@@ -675,16 +674,13 @@ public class Helper {
       }
       final File graphML = api.subgraphForQuery(toplevelCorpusName, aql, QueryLanguage.AQL,
           AnnotationComponentType.PARTOF);
-      final SCorpusGraph cg = CorpusGraphMapper.map(graphML);
-      for (final SNode n : cg.getNodes()) {
-        result.addAll(n.getMetaAnnotations());
-      }
+      return CorpusGraphMapper.map(graphML);
     } catch (ApiException | XMLStreamException | IOException ex) {
       log.error(null, ex);
       ui.access(() -> ExceptionDialog.show(ex, "Could not retrieve metadata", ui));
     }
 
-    return result;
+    return SaltFactory.createSCorpusGraph();
   }
 
   /**

--- a/src/main/java/org/corpus_tools/annis/gui/MetaDataPanel.java
+++ b/src/main/java/org/corpus_tools/annis/gui/MetaDataPanel.java
@@ -148,6 +148,28 @@ public class MetaDataPanel extends Panel {
       }
       return hasResult;
     }
+
+    /**
+     * Places a label in the middle center of the corpus browser panel.
+     */
+    private void addEmptyLabel() {
+      if (emptyLabel == null) {
+        emptyLabel = new Label("none");
+      }
+
+      if (corpusAnnotationTable != null) {
+        layout.removeComponent(corpusAnnotationTable);
+      }
+
+      layout.addComponent(emptyLabel);
+
+      // this has only an effect after adding the component to a parent. Bug by
+      // vaadin?
+      emptyLabel.setSizeUndefined();
+
+      layout.setComponentAlignment(emptyLabel, Alignment.MIDDLE_CENTER);
+      layout.setExpandRatio(emptyLabel, 1.0f);
+    }
   }
 
   /**
@@ -196,27 +218,6 @@ public class MetaDataPanel extends Panel {
 
   }
 
-  /**
-   * Places a label in the middle center of the corpus browser panel.
-   */
-  private void addEmptyLabel() {
-    if (emptyLabel == null) {
-      emptyLabel = new Label("none");
-    }
-
-    if (corpusAnnotationTable != null) {
-      layout.removeComponent(corpusAnnotationTable);
-    }
-
-    layout.addComponent(emptyLabel);
-
-    // this has only an effect after adding the component to a parent. Bug by
-    // vaadin?
-    emptyLabel.setSizeUndefined();
-
-    layout.setComponentAlignment(emptyLabel, Alignment.MIDDLE_CENTER);
-    layout.setExpandRatio(emptyLabel, 1.0f);
-  }
 
   @Override
   public void attach() {

--- a/src/main/java/org/corpus_tools/annis/gui/MetaDataPanel.java
+++ b/src/main/java/org/corpus_tools/annis/gui/MetaDataPanel.java
@@ -45,10 +45,111 @@ import org.eclipse.emf.common.util.URI;
  *
  * // TODO cleanup the toplevelCorpus side effects.
  *
- * @author Thomas Krause {@literal <krauseto@hu-berlin.de>}
+ * @author Thomas Krause {@literal <thomas.krause@hu-berlin.de>}
  * @author Benjamin Weißenfels {@literal <b.pixeldrama@gmail.com>}
  */
 public class MetaDataPanel extends Panel {
+  private final class MetadataAvailableCallback implements FutureCallback<SCorpusGraph> {
+    @Override
+    public void onFailure(Throwable t) {
+      layout.removeComponent(progress);
+      ExceptionDialog.show(t, "Could not get meta data", getUI());
+    }
+
+    @Override
+    public void onSuccess(SCorpusGraph result) {
+      layout.removeComponent(progress);
+      Accordion accordion = new Accordion();
+      accordion.setSizeFull();
+
+
+      boolean hasDocument = addDocumentMetadata(result, accordion);
+      boolean hasCorpus = addCorpusMetadata(result, accordion);
+
+      // set output to none if no metadata are available
+      if (hasDocument || hasCorpus) {
+        layout.addComponent(accordion);
+      } else {
+        addEmptyLabel();
+      }
+    }
+
+    private boolean addCorpusMetadata(SCorpusGraph result, Accordion accordion) {
+      boolean hasResult = false;
+
+      // Sort the (sub-) corpora so sub-corpora come first
+      List<SCorpus> corpora = new ArrayList<>(result.getCorpora());
+      corpora.sort((c1, c2) -> {
+        URI u1 = c1.getPath();
+        URI u2 = c2.getPath();
+        return ComparisonChain.start().compare(u1.segmentCount(), u2.segmentCount())
+            .compare(u1.toString(), u2.toString()).result();
+      });
+
+      for (SCorpus c : corpora) {
+        List<Annotation> corpusAnnos = new ArrayList<>();
+        for (SMetaAnnotation metaAnno : c.getMetaAnnotations()) {
+          Annotation anno = new Annotation();
+          AnnoKey key = new AnnoKey();
+          key.setNs(metaAnno.getNamespace());
+          key.setName(metaAnno.getName());
+          anno.setKey(key);
+          anno.setVal(metaAnno.getValue_STEXT());
+          corpusAnnos.add(anno);
+        }
+
+        if (!corpusAnnos.isEmpty()) {
+          String path = c.getPath().toString();
+          if (path.startsWith("salt:/")) {
+            path = path.substring("salt:/".length());
+          }
+          path = path + " (corpus)";
+          accordion.addTab(setupTable(new ListDataProvider<>(corpusAnnos)), path);
+          hasResult = true;
+        }
+      }
+      return hasResult;
+    }
+
+    private boolean addDocumentMetadata(SCorpusGraph result, Accordion accordion) {
+      boolean hasResult = false;
+
+      // Add all document metadata first, then the corpus metadata
+      List<SDocument> documents = result.getDocuments();
+      if (documents != null) {
+        // There should only be one document in the corpus graph, but keeping the code generic
+        // should not hurt
+        for (SDocument d : documents) {
+          List<Annotation> docAnnos = new ArrayList<>();
+          for (SMetaAnnotation metaAnno : d.getMetaAnnotations()) {
+            Annotation anno = new Annotation();
+            AnnoKey key = new AnnoKey();
+            key.setNs(metaAnno.getNamespace());
+            key.setName(metaAnno.getName());
+            anno.setKey(key);
+            anno.setVal(metaAnno.getValue_STEXT());
+            docAnnos.add(anno);
+          }
+
+          if (!docAnnos.isEmpty()) {
+            String path = d.getName();
+
+            // In case we are called to only output a corpus, this might have been mapped as
+            // document. So only add the "document" suffix in case we are sure it is an actual
+            // corpus.
+            if (documentName.isPresent()) {
+              path = path + " (document)";
+            }
+
+            accordion.addTab(setupTable(new ListDataProvider<>(docAnnos)), path);
+            hasResult = true;
+          }
+        }
+      }
+      return hasResult;
+    }
+  }
+
   /**
    * 
    */
@@ -124,96 +225,7 @@ public class MetaDataPanel extends Panel {
     final UI ui = getUI();
 
     Background.runWithCallback(() -> Helper.getMetaData(toplevelCorpusName, documentName, ui),
-        new FutureCallback<SCorpusGraph>() {
-      @Override
-      public void onFailure(Throwable t) {
-        layout.removeComponent(progress);
-        ExceptionDialog.show(t, "Could not get meta data", getUI());
-      }
-
-      @Override
-      public void onSuccess(SCorpusGraph result) {
-        layout.removeComponent(progress);
-        Accordion accordion = new Accordion();
-        accordion.setSizeFull();
-
-        boolean hasResult = false;
-
-        // Add all document metadata first, then the corpus metadata
-        List<SDocument> documents = result.getDocuments();
-        if (documents != null) {
-          // There should only be one document in the corpus graph, but keeping the code generic
-          // should not hurt
-          for (SDocument d : documents) {
-            List<Annotation> docAnnos = new ArrayList<>();
-            for (SMetaAnnotation metaAnno : d.getMetaAnnotations()) {
-              Annotation anno = new Annotation();
-              AnnoKey key = new AnnoKey();
-              key.setNs(metaAnno.getNamespace());
-              key.setName(metaAnno.getName());
-              anno.setKey(key);
-              anno.setVal(metaAnno.getValue_STEXT());
-              docAnnos.add(anno);
-            }
-
-            if (!docAnnos.isEmpty()) {
-              String path = d.getName();
-
-              // In case we are called to only output a corpus, this might have been mapped as
-              // document. So only add the "document" suffix in case we are sure it is an actual
-              // corpus.
-              if (documentName.isPresent()) {
-                path = path + " (document)";
-              }
-
-              accordion.addTab(setupTable(new ListDataProvider<>(docAnnos)), path);
-              hasResult = true;
-            }
-          }
-
-
-        }
-        // Sort the (sub-) corpora so sub-corpora come first
-        List<SCorpus> corpora = new ArrayList<>(result.getCorpora());
-        corpora.sort((c1, c2) -> {
-          URI u1 = c1.getPath();
-          URI u2 = c2.getPath();
-          return ComparisonChain.start().compare(u1.segmentCount(), u2.segmentCount())
-              .compare(u1.toString(), u2.toString()).result();
-        });
-
-        for (SCorpus c : corpora) {
-          List<Annotation> corpusAnnos = new ArrayList<>();
-          for (SMetaAnnotation metaAnno : c.getMetaAnnotations()) {
-            Annotation anno = new Annotation();
-            AnnoKey key = new AnnoKey();
-            key.setNs(metaAnno.getNamespace());
-            key.setName(metaAnno.getName());
-            anno.setKey(key);
-            anno.setVal(metaAnno.getValue_STEXT());
-            corpusAnnos.add(anno);
-          }
-
-          if (!corpusAnnos.isEmpty()) {
-            String path = c.getPath().toString();
-            if (path.startsWith("salt:/")) {
-              path = path.substring("salt:/".length());
-            }
-            path = path + " (corpus)";
-            accordion.addTab(setupTable(new ListDataProvider<>(corpusAnnos)), path);
-            hasResult = true;
-          }
-        }
-
-        // set output to none if no metadata are available
-        if (hasResult) {
-          layout.addComponent(accordion);
-        } else {
-          addEmptyLabel();
-        }
-      }
-    });
-
+        new MetadataAvailableCallback());
   }
 
   private Grid<Annotation> setupTable(ListDataProvider<Annotation> metaData) {

--- a/src/main/java/org/corpus_tools/annis/gui/MetaDataPanel.java
+++ b/src/main/java/org/corpus_tools/annis/gui/MetaDataPanel.java
@@ -171,7 +171,7 @@ public class MetaDataPanel extends Panel {
 
         }
         // Sort the (sub-) corpora so sub-corpora come first
-        List<SCorpus> corpora = result.getCorpora();
+        List<SCorpus> corpora = new ArrayList<>(result.getCorpora());
         corpora.sort(new Comparator<SCorpus>() {
           public int compare(SCorpus c1, SCorpus c2) {
             URI u1 = c1.getPath();

--- a/src/main/java/org/corpus_tools/annis/gui/MetaDataPanel.java
+++ b/src/main/java/org/corpus_tools/annis/gui/MetaDataPanel.java
@@ -29,7 +29,6 @@ import com.vaadin.ui.ProgressBar;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import org.corpus_tools.annis.api.model.AnnoKey;
@@ -124,10 +123,8 @@ public class MetaDataPanel extends Panel {
 
     final UI ui = getUI();
 
-    Background.runWithCallback(() -> {
-      // Get the corpus graph and with it the meta data on the corpus/document nodes
-      return Helper.getMetaData(toplevelCorpusName, documentName, ui);
-    }, new FutureCallback<SCorpusGraph>() {
+    Background.runWithCallback(() -> Helper.getMetaData(toplevelCorpusName, documentName, ui),
+        new FutureCallback<SCorpusGraph>() {
       @Override
       public void onFailure(Throwable t) {
         layout.removeComponent(progress);
@@ -178,13 +175,11 @@ public class MetaDataPanel extends Panel {
         }
         // Sort the (sub-) corpora so sub-corpora come first
         List<SCorpus> corpora = new ArrayList<>(result.getCorpora());
-        corpora.sort(new Comparator<SCorpus>() {
-          public int compare(SCorpus c1, SCorpus c2) {
-            URI u1 = c1.getPath();
-            URI u2 = c2.getPath();
-            return ComparisonChain.start().compare(u1.segmentCount(), u2.segmentCount())
-                .compare(u1.toString(), u2.toString()).result();
-          };
+        corpora.sort((c1, c2) -> {
+          URI u1 = c1.getPath();
+          URI u2 = c2.getPath();
+          return ComparisonChain.start().compare(u1.segmentCount(), u2.segmentCount())
+              .compare(u1.toString(), u2.toString()).result();
         });
 
         for (SCorpus c : corpora) {

--- a/src/main/java/org/corpus_tools/annis/gui/MetaDataPanel.java
+++ b/src/main/java/org/corpus_tools/annis/gui/MetaDataPanel.java
@@ -160,8 +160,14 @@ public class MetaDataPanel extends Panel {
             }
 
             if (!docAnnos.isEmpty()) {
-              String path = documentName.isPresent() ? "document: " + d.getName()
-                  : "corpus: " + toplevelCorpusName;
+              String path = d.getName();
+
+              // In case we are called to only output a corpus, this might have been mapped as
+              // document. So only add the "document" suffix in case we are sure it is an actual
+              // corpus.
+              if (documentName.isPresent()) {
+                path = path + " (document)";
+              }
 
               accordion.addTab(setupTable(new ListDataProvider<>(docAnnos)), path);
               hasResult = true;
@@ -195,6 +201,10 @@ public class MetaDataPanel extends Panel {
 
           if (!corpusAnnos.isEmpty()) {
             String path = c.getPath().toString();
+            if (path.startsWith("salt:/")) {
+              path = path.substring("salt:/".length());
+            }
+            path = path + " (corpus)";
             accordion.addTab(setupTable(new ListDataProvider<>(corpusAnnos)), path);
             hasResult = true;
           }

--- a/src/main/java/org/corpus_tools/annis/gui/exporter/CSVExporter.java
+++ b/src/main/java/org/corpus_tools/annis/gui/exporter/CSVExporter.java
@@ -200,7 +200,10 @@ public class CSVExporter extends BaseMatrixExporter {
       // TODO is this the best way to get the corpus name?
       String corpusName = Helper.getCorpusPath(graph.getDocument().getId()).get(0);
       // TODO cache the metadata
-      List<SMetaAnnotation> metaAnnos = Helper.getMetaData(corpusName, Optional.of(graph.getDocument().getName()), ui);
+      List<SMetaAnnotation> metaAnnos = new ArrayList<>();
+      for(SNode n : Helper.getMetaData(corpusName, Optional.of(graph.getDocument().getName()), ui).getNodes()) {
+        metaAnnos.addAll(n.getMetaAnnotations());
+      }
       Multimap<String, SMetaAnnotation> metaAnnosByName = Multimaps.index(metaAnnos, SMetaAnnotation::getName);
 
       for (String metaName : metakeys) {

--- a/src/main/java/org/corpus_tools/annis/gui/exporter/GeneralTextExporter.java
+++ b/src/main/java/org/corpus_tools/annis/gui/exporter/GeneralTextExporter.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -50,6 +51,7 @@ import org.corpus_tools.salt.common.SToken;
 import org.corpus_tools.salt.common.SaltProject;
 import org.corpus_tools.salt.core.SFeature;
 import org.corpus_tools.salt.core.SMetaAnnotation;
+import org.corpus_tools.salt.core.SNode;
 
 public abstract class GeneralTextExporter implements ExporterPlugin, Serializable {
 
@@ -65,8 +67,12 @@ public abstract class GeneralTextExporter implements ExporterPlugin, Serializabl
     if (metadataCache.containsKey(toplevelCorpus + ":" + documentName)) {
       metaData = metadataCache.get(toplevelCorpus + ":" + documentName);
     } else {
-      List<SMetaAnnotation> asList =
-          Helper.getMetaData(toplevelCorpus, Optional.ofNullable(documentName), ui);
+
+      List<SMetaAnnotation> asList = new ArrayList<>();
+      for (SNode n : Helper.getMetaData(toplevelCorpus, Optional.ofNullable(documentName), ui)
+          .getNodes()) {
+        asList.addAll(n.getMetaAnnotations());
+      }
       for (SMetaAnnotation anno : asList) {
         metaData.put(anno.getQName(), anno);
         metaData.put(anno.getName(), anno);

--- a/src/main/java/org/corpus_tools/annis/gui/exporter/TextColumnExporter.java
+++ b/src/main/java/org/corpus_tools/annis/gui/exporter/TextColumnExporter.java
@@ -635,8 +635,12 @@ public class TextColumnExporter extends BaseMatrixExporter { // NO_UCD (use defa
               Helper.getCorpusPath(graph.getDocument().getGraph(), graph.getDocument());
           String corpusName = corpusPath.get(corpusPath.size() - 1);
           corpusName = urlPathEscape.escape(corpusName);
-          List<SMetaAnnotation> metadata =
-              Helper.getMetaData(corpusName, Optional.of(docName), ui);
+          
+          List<SMetaAnnotation> metadata = new ArrayList<>();
+          for(SNode n : Helper.getMetaData(corpusName, Optional.of(docName), ui).getNodes()) {
+            metadata.addAll(n.getMetaAnnotations());
+          }
+          
 
           Map<String, String> annosWithoutNamespace = new HashMap<String, String>();
           Map<String, Map<String, String>> annosWithNamespace = new HashMap<>();

--- a/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 import kotlin.Pair;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
+import org.corpus_tools.annis.api.model.Annotation;
 import org.corpus_tools.annis.api.model.FindQuery.OrderEnum;
 import org.corpus_tools.annis.gui.components.ExceptionDialog;
 import org.corpus_tools.annis.gui.components.codemirror.AqlCodeEditor;
@@ -231,6 +232,20 @@ class AnnisUITest {
     assertEquals(2, metadataGrids.size());
     assertEquals("11299 (document)", metaAccordion.getTab(metadataGrids.get(0)).getCaption());
     assertEquals("pcc2 (corpus)", metaAccordion.getTab(metadataGrids.get(1)).getCaption());
+
+    @SuppressWarnings("unchecked")
+    Annotation firstAnno = (Annotation) GridKt._get(metadataGrids.get(0), 0);
+    assertEquals("Dokumentname", firstAnno.getKey().getName());
+    assertEquals("pcc-11299", firstAnno.getVal());
+    @SuppressWarnings("unchecked")
+    Annotation secondAnno = (Annotation) GridKt._get(metadataGrids.get(0), 1);
+    assertEquals("Genre", secondAnno.getKey().getName());
+    assertEquals("Politik", secondAnno.getVal());
+    @SuppressWarnings("unchecked")
+    Annotation thirdAnno = (Annotation) GridKt._get(metadataGrids.get(0), 2);
+    assertEquals("Titel", thirdAnno.getKey().getName());
+    assertEquals("Feigenblatt", thirdAnno.getVal());
+
 
 
     // Disable the part-of-speech token annotation display

--- a/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
@@ -20,6 +20,7 @@ import com.vaadin.icons.VaadinIcons;
 import com.vaadin.server.Page;
 import com.vaadin.shared.ui.ContentMode;
 import com.vaadin.spring.internal.UIScopeImpl;
+import com.vaadin.ui.Accordion;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.ComboBox;
 import com.vaadin.ui.Component;
@@ -214,6 +215,23 @@ class AnnisUITest {
     assertEquals(Arrays.asList("NN", "ART", "NN", "APPR", "NE", "VMFIN"),
         posRows.get(0).getEvents().stream().map(GridEvent::getValue).collect(Collectors.toList()));
 
+    // Test that we can show the first metadata for the button
+    List<Button> infoButtons = _find(Button.class,
+        spec -> spec.withPredicate(b -> "Show metadata".equals(b.getDescription())));
+    assertEquals(10, infoButtons.size());
+    _click(infoButtons.get(0));
+    Window infoWindow = _get(Window.class);
+    assertEquals("Info for salt:/pcc2/11299", infoWindow.getCaption());
+
+    awaitCondition(30, () -> !_find(infoWindow, Accordion.class).isEmpty());
+
+    Accordion metaAccordion = _get(infoWindow, Accordion.class);
+    @SuppressWarnings("rawtypes")
+    List<Grid> metadataGrids = _find(metaAccordion, Grid.class);
+    assertEquals(2, metadataGrids.size());
+    assertEquals("11299 (document)", metaAccordion.getTab(metadataGrids.get(0)).getCaption());
+    assertEquals("pcc2 (corpus)", metaAccordion.getTab(metadataGrids.get(1)).getCaption());
+
 
     // Disable the part-of-speech token annotation display
     TreeSet<String> visibleAnnos = new TreeSet<>(Arrays.asList("tiger::lemma"));
@@ -332,8 +350,6 @@ class AnnisUITest {
 
     // The standard SingleResult panel should not be visible
     assertEquals(0, _find(SingleResultPanel.class).size());
-
-
   }
 
   @Test

--- a/src/test/java/org/corpus_tools/annis/gui/MetaDataPanelTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/MetaDataPanelTest.java
@@ -22,8 +22,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.corpus_tools.annis.api.model.Annotation;
-import org.corpus_tools.annis.gui.AnnisUI;
-import org.corpus_tools.annis.gui.MetaDataPanel;
 import org.corpus_tools.annis.gui.controlpanel.CorpusListPanel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,7 +71,7 @@ class MetaDataPanelTest {
     awaitCondition(30, () -> _find(w, ProgressBar.class).isEmpty());
 
     Accordion accordion = _get(metaPanel, Accordion.class);
-    assertEquals("corpus: pcc2", accordion.getTab(0).getCaption());
+    assertEquals("pcc2", accordion.getTab(0).getCaption());
     @SuppressWarnings("unchecked")
     Grid<Annotation> metaGrid = _get(metaPanel, Grid.class);
 


### PR DESCRIPTION
This adds support for showing the corpus metadata in addition to the document metadata in the match list.

Fixes #768 