### PR TITLE
Do not skip error messages when started service is aborted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not skip error messages when started service is aborted. (#761)
+
 ## [4.7.1] - 2022-05-30
 
 ### Fixed

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
@@ -111,7 +111,7 @@ public class ServiceStarter
                 new InputStreamReader(backgroundProcess.getErrorStream(), StandardCharsets.UTF_8));
 
             tReaderOut = new Thread(() -> {
-              while (!this.abortThread.get() && backgroundProcess.isAlive()) {
+              while (!this.abortThread.get()) {
                 String line;
                 try {
                   line = outputStream.readLine();
@@ -129,7 +129,7 @@ public class ServiceStarter
             });
             tReaderOut.start();
             tReaderErr = new Thread(() -> {
-              while (!this.abortThread.get() && backgroundProcess.isAlive()) {
+              while (!this.abortThread.get()) {
                 String line;
                 try {
                   line = errorStream.readLine();


### PR DESCRIPTION
This could happen e.g. because graphANNIS refuses to start.
This fixes #761