### PR TITLE
Automatically restart the bundled web service when it crashed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow to change the displayed order of corpus metadata annotations using the
   `corpus_annotation_order` configuration in the `corpus-config.toml`
-  file.(#500)
+  file.(#500
+- Automatically restart the bundled web service when it crashed.  
 
 ## [4.8.0] - 2022-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow to change the displayed order of corpus metadata annotations using the
   `corpus_annotation_order` configuration in the `corpus-config.toml`
   file.(#500
-- Automatically restart the bundled web service when it crashed.  
+- Automatically restart the bundled web service when it crashed.
+
+### Fixed
+
+- Only show warning on MacOS with M1 processor instead if exiting.
+- Use several lines for showing the MacOS M1 warning, because there is no
+  automatic line brake.
 
 ## [4.8.0] - 2022-05-31
 

--- a/src/main/java/org/corpus_tools/annis/gui/AnnisBaseUI.java
+++ b/src/main/java/org/corpus_tools/annis/gui/AnnisBaseUI.java
@@ -146,24 +146,26 @@ public class AnnisBaseUI extends UI implements Serializable {
    * @param wrapperClass Name of the wrapper class (a CSS class that is applied to a parent element)
    */
   public void injectUniqueCSS(String cssContent, String wrapperClass) {
-    if (alreadyAddedCSS == null) {
-      alreadyAddedCSS = new TreeSet<String>();
-    }
-
-    final String wrappedCssContent =
-        wrapperClass == null ? cssContent : wrapCSS(cssContent, wrapperClass);
-
-
-    if (wrappedCssContent != null) {
-      String hashForCssContent =
-          Hashing.md5().hashString(wrappedCssContent, StandardCharsets.UTF_8).toString();
-
-      if (!alreadyAddedCSS.contains(hashForCssContent)) {
-
-        alreadyAddedCSS.add(hashForCssContent);
-        this.accessSynchronously(() -> this.getPage().getStyles().add(wrappedCssContent));
+    this.access(() -> {
+      if (alreadyAddedCSS == null) {
+        alreadyAddedCSS = new TreeSet<String>();
       }
-    }
+
+      final String wrappedCssContent =
+          wrapperClass == null ? cssContent : wrapCSS(cssContent, wrapperClass);
+
+
+      if (wrappedCssContent != null) {
+        String hashForCssContent =
+            Hashing.md5().hashString(wrappedCssContent, StandardCharsets.UTF_8).toString();
+
+        if (!alreadyAddedCSS.contains(hashForCssContent)) {
+
+          alreadyAddedCSS.add(hashForCssContent);
+          this.getPage().getStyles().add(wrappedCssContent);
+        }
+      }
+    });
   }
 
   protected Map<String, InstanceConfig> loadInstanceConfig() {

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
@@ -282,7 +282,8 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
       if (!this.backgroundProcess.waitFor(5, TimeUnit.SECONDS)) {
         // Destroy the process by force after 5 seconds
         log.warn("GraphANNIS process did not stop after 5 seconds, stopping it forcefully");
-        this.backgroundProcess.destroyForcibly().waitFor();
+        int result = this.backgroundProcess.destroyForcibly().waitFor();
+        log.warn("GraphANNIS result code was {}", result);
       } else {
         log.info("Stopped graphANNIS process");
       }

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
@@ -86,7 +86,7 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
           }
         }
       };
-      serviceWatcherTimer.scheduleAtFixedRate(serviceWatcherTask, 2500, 2500);
+      serviceWatcherTimer.schedule(serviceWatcherTask, 2500, 2500);
     }
   }
 
@@ -267,6 +267,8 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
 
     if (this.serviceWatcherTimer != null) {
       this.serviceWatcherTimer.cancel();
+      int purgedTasks = this.serviceWatcherTimer.purge();
+      log.debug("Cancelled {} graphANNIS service watchdog tasks", purgedTasks);
     }
 
     if (this.tReaderOut != null) {

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
@@ -278,10 +278,11 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
     }
 
     if (this.backgroundProcess != null) {
+      log.info("Attempting to stop graphANNIS process");
       this.backgroundProcess.destroy();
-      if (!this.backgroundProcess.waitFor(5, TimeUnit.SECONDS)) {
-        // Destroy the process by force after 5 seconds
-        log.warn("GraphANNIS process did not stop after 5 seconds, stopping it forcefully");
+      if (!this.backgroundProcess.waitFor(15, TimeUnit.SECONDS)) {
+        // Destroy the process by force after 15 seconds
+        log.warn("GraphANNIS process did not stop after 15 seconds, stopping it forcefully");
         int result = this.backgroundProcess.destroyForcibly().waitFor();
         log.warn("GraphANNIS result code was {}", result);
       } else {

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
@@ -66,13 +66,14 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
 
   private Thread tReaderErr;
 
+  private Timer serviceWatcherTimer;
+
 
   @Override
   public void onApplicationEvent(final ApplicationReadyEvent event) {
     if (config.getWebserviceUrl() == null || config.getWebserviceUrl().isEmpty()) {
       startService();
-      // Add callback when the process is exited so we can restart it when necessary
-      Timer serviceWatcherTime = new Timer(true);
+      serviceWatcherTimer = new Timer(true);
       TimerTask serviceWatcherTask = new TimerTask() {
 
         @Override
@@ -85,7 +86,7 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
           }
         }
       };
-      serviceWatcherTime.scheduleAtFixedRate(serviceWatcherTask, 2500, 2500);
+      serviceWatcherTimer.scheduleAtFixedRate(serviceWatcherTask, 2500, 2500);
     }
   }
 
@@ -262,6 +263,10 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
   @Override
   public void destroy() throws Exception {
     this.abortThread.set(true);
+
+    if (this.serviceWatcherTimer != null) {
+      this.serviceWatcherTimer.cancel();
+    }
 
     if (this.tReaderOut != null) {
       this.tReaderOut.interrupt();

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
@@ -222,7 +222,7 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
               + "but your version of Java uses the M1 processor natively.\n\n"
               + "You can try to install and use the Adoptium OpenJDK Java Version 11\n"
               + "from https://adoptium.net to run ANNIS and make sure Rosetta is used.",
-          "Cannot run ANNIS on incompatible operating system", JOptionPane.WARNING_MESSAGE);
+          "ANNIS not tested on MacOS with M1 processor", JOptionPane.WARNING_MESSAGE);
     } else if (!("amd64".equals(SystemUtils.OS_ARCH) || "x86_64".equals(SystemUtils.OS_ARCH))) {
       // Completely unsupported system, show error and exit
       JOptionPane.showMessageDialog(null,

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
@@ -225,9 +225,9 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
                 + "You can try to install and use the Adoptium OpenJDK Java Version 11\n"
                 + "from https://adoptium.net to run ANNIS and make sure Rosetta is used.",
             "ANNIS not tested on MacOS with M1 processor", JOptionPane.WARNING_MESSAGE);
-        showApplicationWindow();
-        openBrowser(webURL);
       }
+      showApplicationWindow();
+      openBrowser(webURL);
     } else {
       // No supported system detected, show error and exit
       JOptionPane.showMessageDialog(null,

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
@@ -216,26 +216,28 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
           webURL);
     } else if (!("amd64".equals(SystemUtils.OS_ARCH) || "x86_64".equals(SystemUtils.OS_ARCH))) {
       if (SystemUtils.IS_OS_MAC_OSX && "aarch64".equals(SystemUtils.OS_ARCH)) {
+        // Show warning, but still run ANNIS
         JOptionPane.showMessageDialog(null,
-            "ANNIS can only be run on Apple M1 systems using the Rosetta emulator "
-                + "(https://support.apple.com/en-us/HT211861). "
-                + "You can try to install and use the Adoptium OpenJDK Java 11 from "
-                + "https://adoptium.net to run ANNIS.",
-            "Cannot run ANNIS on incompatible operating system", JOptionPane.ERROR_MESSAGE);
+            "ANNIS is not tested on Apple M1 systems yet!\n"
+                + "It is prefered to use the Rosetta emulator,\n"
+                + "but your version of Java uses the M1 processor natively.\n\n"
+                + "You can try to install and use the Adoptium OpenJDK Java Version 11\n"
+                + "from https://adoptium.net to run ANNIS and make sure Rosetta is used.",
+            "Cannot run ANNIS on incompatible operating system", JOptionPane.WARNING_MESSAGE);
       } else {
+        // Completly unsupported system, show error and exit
         JOptionPane.showMessageDialog(null,
-            "ANNIS can only be run on 64 bit operating systems (\"amd64\" or \"x86_64\") "
-                + "and with a 64 bit version of Java, "
+            "ANNIS can only be run on 64 bit operating systems (\"amd64\" or \"x86_64\")\n"
+                + "and with a 64 bit version of Java,\n"
                 + "but this computer is reported as architecture " + SystemUtils.OS_ARCH + "!\n\n"
-                + "A common cause is that a 32 bit version of Java is installed. "
-                + "Make sure to install a 64 bit Java 11 e.g. from https://adoptium.net",
+                + "A common cause is that a 32 bit version of Java is installed.\n"
+                + "Make sure to install a 64 bit Java 11\n" + "e.g. from https://adoptium.net",
             "Cannot run ANNIS on incompatible operating system", JOptionPane.ERROR_MESSAGE);
+        System.exit(64);
       }
-      System.exit(64);
-    } else {
-      showApplicationWindow();
-      openBrowser(webURL);
     }
+    showApplicationWindow();
+    openBrowser(webURL);
   }
 
   private void openBrowser(String webURL) {

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
@@ -214,27 +214,25 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
       log.warn(
           "ANNIS is running in desktop mode, but no desktop has been detected. You can open {} manually.",
           webURL);
+    } else if (SystemUtils.IS_OS_MAC_OSX && "aarch64".equals(SystemUtils.OS_ARCH)) {
+      // Show warning, but still run ANNIS
+      JOptionPane.showMessageDialog(null,
+          "ANNIS is not tested on Apple M1 systems yet!\n"
+              + "It is prefered to use the Rosetta emulator,\n"
+              + "but your version of Java uses the M1 processor natively.\n\n"
+              + "You can try to install and use the Adoptium OpenJDK Java Version 11\n"
+              + "from https://adoptium.net to run ANNIS and make sure Rosetta is used.",
+          "Cannot run ANNIS on incompatible operating system", JOptionPane.WARNING_MESSAGE);
     } else if (!("amd64".equals(SystemUtils.OS_ARCH) || "x86_64".equals(SystemUtils.OS_ARCH))) {
-      if (SystemUtils.IS_OS_MAC_OSX && "aarch64".equals(SystemUtils.OS_ARCH)) {
-        // Show warning, but still run ANNIS
-        JOptionPane.showMessageDialog(null,
-            "ANNIS is not tested on Apple M1 systems yet!\n"
-                + "It is prefered to use the Rosetta emulator,\n"
-                + "but your version of Java uses the M1 processor natively.\n\n"
-                + "You can try to install and use the Adoptium OpenJDK Java Version 11\n"
-                + "from https://adoptium.net to run ANNIS and make sure Rosetta is used.",
-            "Cannot run ANNIS on incompatible operating system", JOptionPane.WARNING_MESSAGE);
-      } else {
-        // Completly unsupported system, show error and exit
-        JOptionPane.showMessageDialog(null,
-            "ANNIS can only be run on 64 bit operating systems (\"amd64\" or \"x86_64\")\n"
-                + "and with a 64 bit version of Java,\n"
-                + "but this computer is reported as architecture " + SystemUtils.OS_ARCH + "!\n\n"
-                + "A common cause is that a 32 bit version of Java is installed.\n"
-                + "Make sure to install a 64 bit Java 11\n" + "e.g. from https://adoptium.net",
-            "Cannot run ANNIS on incompatible operating system", JOptionPane.ERROR_MESSAGE);
-        System.exit(64);
-      }
+      // Completely unsupported system, show error and exit
+      JOptionPane.showMessageDialog(null,
+          "ANNIS can only be run on 64 bit operating systems (\"amd64\" or \"x86_64\")\n"
+              + "and with a 64 bit version of Java,\n"
+              + "but this computer is reported as architecture " + SystemUtils.OS_ARCH + "!\n\n"
+              + "A common cause is that a 32 bit version of Java is installed.\n"
+              + "Make sure to install a 64 bit Java 11\n" + "e.g. from https://adoptium.net",
+          "Cannot run ANNIS on incompatible operating system", JOptionPane.ERROR_MESSAGE);
+      System.exit(64);
     }
     showApplicationWindow();
     openBrowser(webURL);

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
@@ -214,17 +214,22 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
       log.warn(
           "ANNIS is running in desktop mode, but no desktop has been detected. You can open {} manually.",
           webURL);
-    } else if (SystemUtils.IS_OS_MAC_OSX && "aarch64".equals(SystemUtils.OS_ARCH)) {
-      // Show warning, but still run ANNIS
-      JOptionPane.showMessageDialog(null,
-          "ANNIS is not tested on Apple M1 systems yet!\n"
-              + "It is prefered to use the Rosetta emulator,\n"
-              + "but your version of Java uses the M1 processor natively.\n\n"
-              + "You can try to install and use the Adoptium OpenJDK Java Version 11\n"
-              + "from https://adoptium.net to run ANNIS and make sure Rosetta is used.",
-          "ANNIS not tested on MacOS with M1 processor", JOptionPane.WARNING_MESSAGE);
-    } else if (!("amd64".equals(SystemUtils.OS_ARCH) || "x86_64".equals(SystemUtils.OS_ARCH))) {
-      // Completely unsupported system, show error and exit
+    } else if ("amd64".equals(SystemUtils.OS_ARCH) || "x86_64".equals(SystemUtils.OS_ARCH)
+        || SystemUtils.IS_OS_MAC_OSX) {
+      if (SystemUtils.IS_OS_MAC_OSX && "aarch64".equals(SystemUtils.OS_ARCH)) {
+        // Show warning, but still run ANNIS
+        JOptionPane.showMessageDialog(null,
+            "ANNIS is not tested on Apple M1 systems yet!\n"
+                + "It is prefered to use the Rosetta emulator,\n"
+                + "but your version of Java uses the M1 processor natively.\n\n"
+                + "You can try to install and use the Adoptium OpenJDK Java Version 11\n"
+                + "from https://adoptium.net to run ANNIS and make sure Rosetta is used.",
+            "ANNIS not tested on MacOS with M1 processor", JOptionPane.WARNING_MESSAGE);
+        showApplicationWindow();
+        openBrowser(webURL);
+      }
+    } else {
+      // No supported system detected, show error and exit
       JOptionPane.showMessageDialog(null,
           "ANNIS can only be run on 64 bit operating systems (\"amd64\" or \"x86_64\")\n"
               + "and with a 64 bit version of Java,\n"
@@ -234,8 +239,6 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
           "Cannot run ANNIS on incompatible operating system", JOptionPane.ERROR_MESSAGE);
       System.exit(64);
     }
-    showApplicationWindow();
-    openBrowser(webURL);
   }
 
   private void openBrowser(String webURL) {

--- a/src/main/java/org/corpus_tools/annis/gui/visualizers/htmlvis/HTMLVis.java
+++ b/src/main/java/org/corpus_tools/annis/gui/visualizers/htmlvis/HTMLVis.java
@@ -130,8 +130,6 @@ public class HTMLVis extends AbstractVisualizer {
       injectWebFonts(visConfigName, corpusName, rootCorpusId, vi.getUI(),
           new CorporaApi(Helper.getClient(vi.getUI())));
       injectCSS(visConfigName, corpusName, rootCorpusId, wrapperClassName, vi.getUI());
-
-
     }
 
     if (vi.getMappings().containsKey("debug")) {

--- a/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
@@ -43,6 +43,7 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import kotlin.Pair;
+import net.jcip.annotations.NotThreadSafe;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.corpus_tools.annis.api.model.Annotation;
@@ -78,6 +79,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 @SpringBootTest
 @ActiveProfiles({"desktop", "test", "headless"})
 @WebAppConfiguration
+@NotThreadSafe
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 class AnnisUITest {
 

--- a/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
@@ -432,7 +432,8 @@ class AnnisUITest {
     awaitCondition(240,
         () -> !_find(resultPanel, Panel.class,
             spec -> spec.withPredicate(p -> p.getStyleName().startsWith("annis-wrapped-htmlvis-")))
-                .isEmpty());
+                .isEmpty(),
+        2000);
 
     Panel htmlPanel = _get(resultPanel, Panel.class,
         spec -> spec.withPredicate(p -> p.getStyleName().startsWith("annis-wrapped-htmlvis-")));

--- a/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
@@ -43,7 +43,6 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import kotlin.Pair;
-import net.jcip.annotations.NotThreadSafe;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.corpus_tools.annis.api.model.Annotation;
@@ -71,16 +70,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 @SpringBootTest
 @ActiveProfiles({"desktop", "test", "headless"})
 @WebAppConfiguration
-@NotThreadSafe
-@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 class AnnisUITest {
 
   @Autowired

--- a/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
@@ -71,13 +71,14 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 @SpringBootTest
 @ActiveProfiles({"desktop", "test", "headless"})
 @WebAppConfiguration
-@DirtiesContext
+@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 class AnnisUITest {
 
   @Autowired

--- a/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
@@ -429,7 +429,7 @@ class AnnisUITest {
     Button btOpenHtmlVisualizer = _get(resultPanel, Button.class,
         spec -> spec.withCaption("information structure (document)"));
     _click(btOpenHtmlVisualizer);
-    awaitCondition(240,
+    awaitCondition(65,
         () -> !_find(resultPanel, Panel.class,
             spec -> spec.withPredicate(p -> p.getStyleName().startsWith("annis-wrapped-htmlvis-")))
                 .isEmpty(),

--- a/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
@@ -70,12 +70,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 @SpringBootTest
 @ActiveProfiles({"desktop", "test", "headless"})
 @WebAppConfiguration
+@DirtiesContext
 class AnnisUITest {
 
   @Autowired

--- a/src/test/java/org/corpus_tools/annis/gui/TestHelper.java
+++ b/src/test/java/org/corpus_tools/annis/gui/TestHelper.java
@@ -15,7 +15,7 @@ public class TestHelper {
   }
 
   public static void awaitCondition(int seconds, Callable<Boolean> conditionEvaluator,
-      Callable<String> message)
+      Callable<String> message, int sleepTimeInMs)
       throws Exception {
     long startTime = System.currentTimeMillis();
     long maxExecutionTime = ((long) seconds) * 1000l;
@@ -30,8 +30,8 @@ public class TestHelper {
 
       if (!condition) {
         // Wait until invoking the condition again
-        log.debug("Waiting 250 ms before checking condition again");
-        Thread.sleep(250); // NOSONAR The code should similar to the Karibu async example
+        log.debug("Waiting {} ms before checking condition again", sleepTimeInMs);
+        Thread.sleep(sleepTimeInMs); // NOSONAR The code should similar to the Karibu async example
       }
     }
 
@@ -42,9 +42,20 @@ public class TestHelper {
     }
   }
 
+  public static void awaitCondition(int seconds, Callable<Boolean> conditionEvaluator,
+      Callable<String> message) throws Exception {
+    awaitCondition(seconds, conditionEvaluator, message, 250);
+  }
+
   public static void awaitCondition(int seconds, Callable<Boolean> conditionEvaluator)
       throws Exception {
     awaitCondition(seconds, conditionEvaluator,
-        () -> "Condition did not become true in " + seconds + " seconds.");
+        () -> "Condition did not become true in " + seconds + " seconds.", 250);
+  }
+
+  public static void awaitCondition(int seconds, Callable<Boolean> conditionEvaluator,
+      int sleepTimeInMs) throws Exception {
+    awaitCondition(seconds, conditionEvaluator,
+        () -> "Condition did not become true in " + seconds + " seconds.", sleepTimeInMs);
   }
 }

--- a/src/test/java/org/corpus_tools/annis/gui/admin/reflinks/MigrationPanelTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/admin/reflinks/MigrationPanelTest.java
@@ -51,8 +51,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.web.WebAppConfiguration;
 
@@ -60,7 +58,6 @@ import org.springframework.test.context.web.WebAppConfiguration;
 @ActiveProfiles({"desktop", "test", "headless"})
 @WebAppConfiguration
 @NotThreadSafe
-@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 class MigrationPanelTest {
 
   private static final String VALID_PARTIAL_REFERENCE_ENTRY =

--- a/src/test/java/org/corpus_tools/annis/gui/admin/reflinks/MigrationPanelTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/admin/reflinks/MigrationPanelTest.java
@@ -52,6 +52,7 @@ import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.web.WebAppConfiguration;
 
@@ -59,7 +60,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 @ActiveProfiles({"desktop", "test", "headless"})
 @WebAppConfiguration
 @NotThreadSafe
-@DirtiesContext
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 class MigrationPanelTest {
 
   private static final String VALID_PARTIAL_REFERENCE_ENTRY =

--- a/src/test/java/org/corpus_tools/annis/gui/admin/reflinks/MigrationPanelTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/admin/reflinks/MigrationPanelTest.java
@@ -51,6 +51,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.web.WebAppConfiguration;
 
@@ -58,6 +59,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 @ActiveProfiles({"desktop", "test", "headless"})
 @WebAppConfiguration
 @NotThreadSafe
+@DirtiesContext
 class MigrationPanelTest {
 
   private static final String VALID_PARTIAL_REFERENCE_ENTRY =


### PR DESCRIPTION
In the case the bundled web service is crashing, it might be difficult to detect this in uptime monitors (can only be checked by evaluating the JavaScript reaction or probing the REST API). While the service should not crash at all, an automatic restart of the stateless service is the lesser evil of instead just silently failing without stopping the ANNIS frontend.

Also, make the MacOS M1 message only a warning, since the unpacked executable should be able to be run with Rosetta even when Java is run natively.