### PR TITLE
Address issues in #782

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Adressed some non-security issues confusing static code analyzers (#782)
+
 ## [4.9.0] - 2022-06-15
 
 ###  Added

--- a/src/main/java/org/corpus_tools/annis/gui/security/SecurityConfiguration.java
+++ b/src/main/java/org/corpus_tools/annis/gui/security/SecurityConfiguration.java
@@ -99,7 +99,7 @@ public class SecurityConfiguration {
         // Cross-site request forgery running.
         // Spring will try to enforce an additional layer
         // on the filtered resources, which conflicts with
-        // the Vaadin CSRF protection and make the frontend
+        // the Vaadin CSRF protection and makes the frontend
         // unusable. Disabling Spring CSRF is therefore
         // safe, as long as Vaadin CSRF protection is
         // activated (which it is per default).

--- a/src/main/java/org/corpus_tools/annis/gui/security/SecurityConfiguration.java
+++ b/src/main/java/org/corpus_tools/annis/gui/security/SecurityConfiguration.java
@@ -95,7 +95,15 @@ public class SecurityConfiguration {
         // Restrict access to our application.
         .and().authorizeRequests().anyRequest().authenticated()
 
-        // Not using Spring CSRF here to be able to use plain HTML for the login page
+        // Not using Spring CSRF here because Vaadin also has a
+        // Cross-site request forgery running.
+        // Spring will try to enforce an additional layer
+        // on the filtered resources, which conflicts with
+        // the Vaadin CSRF protection and make the frontend
+        // unusable. Disabling Spring CSRF is therefore
+        // safe, as long as Vaadin CSRF protection is
+        // activated (which it is per default).
+        // https://vaadin.com/blog/filter-based-spring-security-in-vaadin-applications
         .and().csrf().disable();
 
     // We depend on IFrames embedded into the application

--- a/src/main/java/org/corpus_tools/annis/gui/servlets/CitationRedirectionServlet.java
+++ b/src/main/java/org/corpus_tools/annis/gui/servlets/CitationRedirectionServlet.java
@@ -1,23 +1,19 @@
 /*
  * Copyright 2011 Corpuslinguistic working group Humboldt University Berlin.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package org.corpus_tools.annis.gui.servlets;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -33,26 +29,26 @@ import org.springframework.stereotype.Component;
 @Component
 public class CitationRedirectionServlet extends HttpServlet { // NO_UCD (use default)
 
-    /**
-     * 
-     */
-    private static final long serialVersionUID = 5264592666872908858L;
-    private static final org.slf4j.Logger log = LoggerFactory.getLogger(CitationRedirectionServlet.class);
+  /**
+   * 
+   */
+  private static final long serialVersionUID = 5264592666872908858L;
+  private static final org.slf4j.Logger log =
+      LoggerFactory.getLogger(CitationRedirectionServlet.class);
 
-    @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
-        try {
-            URI uri = new URI(req.getRequestURI());
-            req.getSession().setAttribute("citation", uri.getPath());
-            resp.sendRedirect(req.getContextPath() + "/");
-          } catch (URISyntaxException | IOException ex) {
-            log.error("Could not redirect citation link", ex);
-            try {
-              resp.sendError(400, "Could not redirect citation link");
-            } catch (IOException sendEx) {
-              log.error("Could not send error to client", sendEx);
-            }
-        }
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+    try {
+      req.getSession().setAttribute("citation", req.getPathInfo());
+      resp.sendRedirect(req.getContextPath() + "/");
+    } catch (IOException ex) {
+      log.error("Could not redirect citation link", ex);
+      try {
+        resp.sendError(400, "Could not redirect citation link");
+      } catch (IOException sendEx) {
+        log.error("Could not send error to client", sendEx);
+      }
     }
+  }
 
 }

--- a/src/main/java/org/corpus_tools/annis/gui/servlets/CitationRedirectionServlet.java
+++ b/src/main/java/org/corpus_tools/annis/gui/servlets/CitationRedirectionServlet.java
@@ -46,9 +46,9 @@ public class CitationRedirectionServlet extends HttpServlet { // NO_UCD (use def
             req.getSession().setAttribute("citation", uri.getPath());
             resp.sendRedirect(req.getContextPath() + "/");
           } catch (URISyntaxException | IOException ex) {
-            log.error(null, ex);
+            log.error("Could not redirect citation link", ex);
             try {
-              resp.sendError(400, ex.getMessage());
+              resp.sendError(400, "Could not redirect citation link");
             } catch (IOException sendEx) {
               log.error("Could not send error to client", sendEx);
             }

--- a/src/test/java/org/corpus_tools/annis/gui/servlets/CitationRedirectionServletTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/servlets/CitationRedirectionServletTest.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import org.corpus_tools.annis.gui.servlets.CitationRedirectionServlet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -48,6 +47,7 @@ class CitationRedirectionServletTest {
     assertEquals(HttpStatus.FOUND, response.getStatusCode());
     assertEquals("http://localhost:" + port + "/", response.getHeaders().get("Location").get(0));
   }
+
 
   @Test
   void handleIOException() throws IOException {


### PR DESCRIPTION
#782 reports two issues found by automatic code analysis which also have been found by Sonarcloud before.

The fix for one of the potential problems is not to include any information from the exception at all, even if only the message (and not as claimed the whole stacktrace) is exposed.

The second issue is not an issue after reviewing this again. But the explanation in the comment why this is needed/ok was wrong.
I updated the comment for future reviewers to explain more what is going on and why this code is safe.