### PR TITLE
Use less main memory for the imported corpora.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Configure CI build jobs to use disk based corpora.
+
 ## [4.9.0] - 2022-06-15
 
 ###  Added

--- a/misc/import-test-corpora.sh
+++ b/misc/import-test-corpora.sh
@@ -5,7 +5,7 @@ curl -L -o dialog.zip https://corpus-tools.org/corpora/dialog.demo_relANNIS.zip
 curl -L -o aeschylus.zip https://corpus-tools.org/corpora/Aeschylus.Persae.L1-18_relAnnis.zip
 curl -L -o shenoute.zip https://corpus-tools.org/corpora/shenoute.a22_ANNIS.zip 
 mkdir -p  $HOME/.annis/v4/
-annis $HOME/.annis/v4/ -c "import pcc2.zip"
-annis $HOME/.annis/v4/ -c "import dialog.zip"
-annis $HOME/.annis/v4/ -c "import aeschylus.zip"
-annis $HOME/.annis/v4/ -c "import shenoute.zip"
+annis $HOME/.annis/v4/ -c 'set-disk-based on' -c "import pcc2.zip"
+annis $HOME/.annis/v4/ -c 'set-disk-based on' -c "import dialog.zip"
+annis $HOME/.annis/v4/ -c 'set-disk-based on' -c "import aeschylus.zip"
+annis $HOME/.annis/v4/ -c 'set-disk-based on' -c "import shenoute.zip"


### PR DESCRIPTION
The backend service in our CI jobs is regulary killed during execution, this might help with the situation