### PR TITLE
Do not restart possible crashed graphANNIS service in integration tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not restart possible crashed graphANNIS service in integration tests.
+
 ## [4.9.0] - 2022-06-15
 
 ###  Added

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
@@ -80,7 +80,8 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
         @Override
         public void run() {
           // Check if the process is crashed and not manually shutdown
-          if (!backgroundProcess.isAlive() && !abortThread.get()) {
+          if (config.isRestartBackendOnCrash() && !backgroundProcess.isAlive()
+              && !abortThread.get()) {
             // Restart the whole process
             log.warn("It seems the bundled graphANNIS service has crashed, restarting it.");
             startService();

--- a/src/main/java/org/corpus_tools/annis/gui/UIConfig.java
+++ b/src/main/java/org/corpus_tools/annis/gui/UIConfig.java
@@ -24,6 +24,8 @@ public class UIConfig implements Serializable {
 
   private boolean shortenReferenceLinks;
   
+  private boolean restartBackendOnCrash;
+
   public String getBugEmail() {
     return bugEMail;
   }
@@ -110,5 +112,15 @@ public class UIConfig implements Serializable {
 
   public void setMailFrom(String mailFrom) {
     this.mailFrom = mailFrom;
+  }
+
+  public boolean isRestartBackendOnCrash() {
+    return restartBackendOnCrash;
+  }
+
+  public void setRestartBackendOnCrash(boolean restartBackendOnCrash) {
+    this.restartBackendOnCrash = restartBackendOnCrash;
   }  
+
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,8 @@ server.port=5712
 
 annis.webservice-config=${user.home}/.annis/service.toml
 
+annis.restart-backend-on-crash=true
+
 # Set to false if you need to debug Vaadin
 vaadin.servlet.productionMode=true
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -4,6 +4,8 @@ annis.shorten-reference-links=true
 server.port=5712
 annis.webservice-config=${user.home}/.annis/service.toml
 
+annis.restart-backend-on-crash=false
+
 spring.datasource.url=jdbc:h2:mem:frontend_data
 # Automatically create and update the schema
 spring.jpa.generate-ddl=true


### PR DESCRIPTION
The Github actions CI has a lot of messages of crashes, which is weird and might be caused by a stressed system environment. Better fail early than attempting to start dozens of graphANNIS services.