### PR TITLE
Avoid issues with possible problematic random number generation in visualizer result ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid issues with possible problematic random number generation in visualizer
+  result ID. Since the ID is only locally used for one match view, the impact of
+  a flawed random generator are limited, but it is still bad practice to create
+  a new random generator each time.
+
 ## [4.9.1] - 2022-06-30
 
 ### Fixed

--- a/src/main/java/org/corpus_tools/annis/gui/resultview/SingleResultPanel.java
+++ b/src/main/java/org/corpus_tools/annis/gui/resultview/SingleResultPanel.java
@@ -33,6 +33,7 @@ import com.vaadin.v7.data.Property;
 import com.vaadin.v7.data.util.IndexedContainer;
 import com.vaadin.v7.ui.AbstractSelect;
 import com.vaadin.v7.ui.ComboBox;
+import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -65,7 +66,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SingleResultPanel extends CssLayout
     implements Button.ClickListener, VisualizerContextChanger {
-  private static final Random RANDOM = new Random();
+  private static final Random RANDOM = new SecureRandom();
 
   private static class AddNewItemHandler implements AbstractSelect.NewItemHandler {
 

--- a/src/main/java/org/corpus_tools/annis/gui/resultview/SingleResultPanel.java
+++ b/src/main/java/org/corpus_tools/annis/gui/resultview/SingleResultPanel.java
@@ -65,6 +65,8 @@ import org.slf4j.LoggerFactory;
  */
 public class SingleResultPanel extends CssLayout
     implements Button.ClickListener, VisualizerContextChanger {
+  private static final Random RANDOM = new Random();
+
   private static class AddNewItemHandler implements AbstractSelect.NewItemHandler {
 
 
@@ -378,7 +380,7 @@ public class SingleResultPanel extends CssLayout
       Map<SNode, Long> markedAndCovered =
           Helper.calculateMarkedAndCovered(result, segNodes, segmentationName);
 
-      String resultID = "" + new Random().nextInt(Integer.MAX_VALUE);
+      String resultID = "" + RANDOM.nextInt(Integer.MAX_VALUE);
 
       int i = 0;
       for (VisualizerRule visRule : resolverEntries) {


### PR DESCRIPTION
Since the ID is only locally used for one match view, the impact of a flawed random generator are limited, but it is still bad practice to create a new random generator each time.