### PR TITLE
Fix mapping of parallel texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multiple texts in parallel corpora where treated as a single text, causing
   several problems. E.g. the KWIC view was showing a single token row with gaps
   instead of several token rows for parallel corpora.
+- Fixed issue with qualified annotation names in HTML visualizer, which resulted
+  in incomplete results.
 
 ## [4.9.1] - 2022-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   result ID. Since the ID is only locally used for one match view, the impact of
   a flawed random generator are limited, but it is still bad practice to create
   a new random generator each time.
+- Multiple texts in parallel corpora where treated as a single text, causing
+  several problems. E.g. the KWIC view was showing a single token row with gaps
+  instead of several token rows for parallel corpora.
 
 ## [4.9.1] - 2022-06-30
 

--- a/misc/import-test-corpora.sh
+++ b/misc/import-test-corpora.sh
@@ -4,8 +4,10 @@ curl -L -o pcc2.zip https://corpus-tools.org/corpora/pcc2_v7_graphml.zip
 curl -L -o dialog.zip https://corpus-tools.org/corpora/dialog.demo_relANNIS.zip
 curl -L -o aeschylus.zip https://corpus-tools.org/corpora/Aeschylus.Persae.L1-18_relAnnis.zip
 curl -L -o shenoute.zip https://corpus-tools.org/corpora/shenoute.a22_ANNIS.zip 
+curl -L -o parallelsample.zip https://corpus-tools.org/corpora/parallel.sample_relAnnis.zip
 mkdir -p  $HOME/.annis/v4/
 annis $HOME/.annis/v4/ -c "import pcc2.zip"
 annis $HOME/.annis/v4/ -c "import dialog.zip"
 annis $HOME/.annis/v4/ -c "import aeschylus.zip"
 annis $HOME/.annis/v4/ -c "import shenoute.zip"
+annis $HOME/.annis/v4/ -c "import parallelsample.zip"

--- a/src/main/java/org/corpus_tools/annis/gui/EmbeddedVisUI.java
+++ b/src/main/java/org/corpus_tools/annis/gui/EmbeddedVisUI.java
@@ -50,7 +50,6 @@ import okhttp3.Response;
 import org.apache.commons.io.IOUtils;
 import org.corpus_tools.annis.ApiClient;
 import org.corpus_tools.annis.api.CorporaApi;
-import org.corpus_tools.annis.api.model.AnnotationComponentType;
 import org.corpus_tools.annis.api.model.QueryLanguage;
 import org.corpus_tools.annis.api.model.SubgraphWithContext;
 import org.corpus_tools.annis.api.model.VisualizerRule;
@@ -230,8 +229,7 @@ public class EmbeddedVisUI extends CommonUI {
       String aql = Helper.buildDocumentQuery(corpusNodeId, null, isUsingRawText);
 
       Background.runWithCallback(
-          () -> api.subgraphForQuery(toplevelCorpus, aql, QueryLanguage.AQL,
-              isUsingRawText ? AnnotationComponentType.ORDERING : null),
+          () -> api.subgraphForQuery(toplevelCorpus, aql, QueryLanguage.AQL, null),
           new GraphMLLoaderCallback(corpusNodeId, visPlugin.get(), args));
 
 

--- a/src/main/java/org/corpus_tools/annis/gui/Helper.java
+++ b/src/main/java/org/corpus_tools/annis/gui/Helper.java
@@ -1176,8 +1176,8 @@ public class Helper {
 
     StringBuilder aql = new StringBuilder();
     if (fallbackToAll) {
-      aql.append("(n#node");
-      aql.append(") & doc#annis:node_name=/");
+      aql.append("n#annis:node_type");
+      aql.append("& doc#annis:node_name=/");
       aql.append(Helper.AQL_REGEX_VALUE_ESCAPER.escape(documentNodeName));
       aql.append("/ & #n @* #doc");
     } else {
@@ -1188,6 +1188,7 @@ public class Helper {
           aql.append(nodeAnno);
         }
       }
+      aql.append(" | a#annis:node_type=\"datasource\"");
 
       aql.append(") & doc#annis:node_name=/");
       aql.append(Helper.AQL_REGEX_VALUE_ESCAPER.escape(documentNodeName));

--- a/src/main/java/org/corpus_tools/annis/gui/Helper.java
+++ b/src/main/java/org/corpus_tools/annis/gui/Helper.java
@@ -180,7 +180,20 @@ public class Helper {
       uri = uri.substring("salt:/".length());
     }
     return uri;
+  }
 
+  /**
+   * Add a legacy id prefix if it does not exist yet.
+   * 
+   * @param uri The original node ID
+   * 
+   * @return The node ID with the "salt:/" prefix
+   */
+  public static String addSaltPrefix(String uri) {
+    if (!uri.startsWith("salt:/")) {
+      uri = "salt:/" + uri;
+    }
+    return uri;
   }
 
   /**

--- a/src/main/java/org/corpus_tools/annis/gui/Helper.java
+++ b/src/main/java/org/corpus_tools/annis/gui/Helper.java
@@ -1176,7 +1176,7 @@ public class Helper {
 
     StringBuilder aql = new StringBuilder();
     if (fallbackToAll) {
-      aql.append("n#annis:node_type");
+      aql.append("n#annis:node_type ");
       aql.append("& doc#annis:node_name=/");
       aql.append(Helper.AQL_REGEX_VALUE_ESCAPER.escape(documentNodeName));
       aql.append("/ & #n @* #doc");

--- a/src/main/java/org/corpus_tools/annis/gui/Helper.java
+++ b/src/main/java/org/corpus_tools/annis/gui/Helper.java
@@ -1184,6 +1184,9 @@ public class Helper {
       aql.append("(a#tok");
       if (nodeAnnoFilter != null) {
         for (String nodeAnno : nodeAnnoFilter) {
+          // This could be a fully qualified annotation name with "::", replace it with an AQL
+          // compatible namespace separator
+          nodeAnno = nodeAnno.replaceFirst("::", ":");
           aql.append(" | a#");
           aql.append(nodeAnno);
         }

--- a/src/main/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserController.java
+++ b/src/main/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserController.java
@@ -38,7 +38,6 @@ import javax.xml.stream.XMLStreamException;
 import org.apache.commons.lang3.StringUtils;
 import org.corpus_tools.annis.ApiException;
 import org.corpus_tools.annis.api.CorporaApi;
-import org.corpus_tools.annis.api.model.AnnotationComponentType;
 import org.corpus_tools.annis.api.model.QueryLanguage;
 import org.corpus_tools.annis.api.model.VisualizerRule;
 import org.corpus_tools.annis.gui.AnnisUI;
@@ -201,8 +200,7 @@ public class DocBrowserController implements Serializable {
 
       // Build a query that includes all (possible filtered by name) node of the document
       String aql = Helper.buildDocumentQuery(documentNodeName, nodeAnnoFilter, useRawText);
-      File graphML = api.subgraphForQuery(corpus, aql, QueryLanguage.AQL,
-          useRawText ? AnnotationComponentType.ORDERING : null);
+      File graphML = api.subgraphForQuery(corpus, aql, QueryLanguage.AQL, null);
 
       SDocumentGraph docGraph = DocumentGraphMapper.map(graphML);
       doc.setDocumentGraph(docGraph);

--- a/src/main/java/org/corpus_tools/annis/gui/graphml/DocumentGraphMapper.java
+++ b/src/main/java/org/corpus_tools/annis/gui/graphml/DocumentGraphMapper.java
@@ -51,6 +51,8 @@ import org.corpus_tools.salt.util.SaltUtil;
  */
 public class DocumentGraphMapper extends AbstractGraphMLMapper {
 
+  private static final String ANNIS_TOK = "annis::tok";
+
   private final class RecreateTextForRootNodeTraverser implements GraphTraverseHandler {
     private final Map<SToken, Range<Integer>> token2Range;
     private final StringBuilder text;
@@ -92,7 +94,7 @@ public class DocumentGraphMapper extends AbstractGraphMLMapper {
           text.append(featTokWhitespaceBefore.getValue().toString());
         }
 
-        SFeature featTok = currNode.getFeature("annis::tok");
+        SFeature featTok = currNode.getFeature(ANNIS_TOK);
         if (featTok != null) {
           int idxStart = text.length();
           text.append(featTok.getValue_STEXT());
@@ -353,7 +355,7 @@ public class DocumentGraphMapper extends AbstractGraphMLMapper {
   private SNode mapNode(String nodeName, Map<String, String> labels) {
     SNode newNode;
 
-    if ((labels.containsKey("annis::tok")) && !hasOutgoingCoverageEdge.contains(nodeName)) {
+    if ((labels.containsKey(ANNIS_TOK)) && !hasOutgoingCoverageEdge.contains(nodeName)) {
       newNode = SaltFactory.createSToken();
     } else if (hasOutgoingDominanceEdge.contains(nodeName)) {
       newNode = SaltFactory.createSStructure();
@@ -481,7 +483,7 @@ public class DocumentGraphMapper extends AbstractGraphMLMapper {
           public void nodeReached(SGraph.GRAPH_TRAVERSE_TYPE traversalType, String traversalId,
               SNode currNode, SRelation<SNode, SNode> relation, SNode fromNode, long order) {
 
-            SFeature featTok = currNode.getFeature("annis::tok");
+            SFeature featTok = currNode.getFeature(ANNIS_TOK);
             if (featTok != null && currNode instanceof SSpan) {
               // only add the annotation if not yet existing (e.g. in another namespace)
               for (SAnnotation existingAnno : currNode.getAnnotations()) {

--- a/src/main/java/org/corpus_tools/annis/gui/objects/RawTextWrapper.java
+++ b/src/main/java/org/corpus_tools/annis/gui/objects/RawTextWrapper.java
@@ -13,8 +13,10 @@
  */
 package org.corpus_tools.annis.gui.objects;
 
+import com.google.common.collect.ComparisonChain;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.corpus_tools.salt.common.SDocumentGraph;
 import org.corpus_tools.salt.common.STextualDS;
@@ -29,7 +31,14 @@ public class RawTextWrapper implements Serializable {
   public RawTextWrapper(SDocumentGraph docGraph) {
     if (docGraph != null) {
       this.texts = new ArrayList<>();
-      for (STextualDS ds : docGraph.getTextualDSs()) {
+
+      // Sort textual data sources by their name
+      List<STextualDS> allDatasources = new ArrayList<>(docGraph.getTextualDSs());
+      Collections.sort(allDatasources,
+          (ds1, ds2) -> ComparisonChain.start().compare(ds1.getName(), ds1.getName())
+              .compare(ds1.getId(), ds2.getId()).result());
+
+      for (STextualDS ds : allDatasources) {
         this.texts.add(ds.getData());
       }
     }

--- a/src/main/java/org/corpus_tools/annis/gui/visualizers/htmlvis/HTMLVis.java
+++ b/src/main/java/org/corpus_tools/annis/gui/visualizers/htmlvis/HTMLVis.java
@@ -156,6 +156,9 @@ public class HTMLVis extends AbstractVisualizer {
     StringBuilder sb = new StringBuilder();
 
     List<SToken> token = graph.getSortedTokenByText();
+    if (token == null) {
+      return "";
+    }
 
     Map<SToken, Long> token2index = new HashMap<>();
     {

--- a/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
@@ -479,7 +479,6 @@ class AnnisUITest {
   void parallelTextKwic() throws Exception {
     executeSearch("parallel.sample", "tok ->align_e-g tok", 5, 1);
 
-
     // Test that there are two KWIC panels with the correct table cells
     SingleResultPanel resultPanel = _find(SingleResultPanel.class).get(0);
     KWICMultipleTextComponent parentKwicVis = _get(resultPanel, KWICMultipleTextComponent.class);
@@ -621,6 +620,32 @@ class AnnisUITest {
         .startsWith("Feigenblatt Die Jugendlichen in Zossen wollen ein Musikcafé ."));
     assertTrue(rawTextLabel.getValue().endsWith("Die glänzten diesmal noch mit Abwesenheit ."));
 
+  }
+
+  @Test
+  void showDocumentRawTextParallel() throws Exception {
+    UI.getCurrent().getNavigator().navigateTo("");
+
+    ui.getSearchView().getDocBrowserController().openDocBrowser("parallel.sample");
+
+    DocBrowserPanel panel = _get(DocBrowserPanel.class);
+
+    awaitCondition(120, () -> !_find(panel, DocBrowserTable.class).isEmpty());
+
+    DocBrowserTable docBrowserTable = _get(panel, DocBrowserTable.class);
+
+    // Click on the button to open the full text visualization for the first document
+    _click(_get(docBrowserTable, Button.class, spec -> spec.withCaption("full text")));
+
+    Component rawTextPanel = ui.getSearchView().getTabSheet().getSelectedTab();
+    Tab selectedTab = ui.getSearchView().getTabSheet().getTab(rawTextPanel);
+    assertEquals("parallel.sample...", selectedTab.getCaption());
+
+    // Wait for label to appear
+    awaitCondition(20, () -> _find(rawTextPanel, Label.class).size() == 2, 1000);
+    List<Label> rawTextLabels = _find(rawTextPanel, Label.class);
+    assertEquals("Das ist ein Beispielsatz . ", rawTextLabels.get(0).getValue());
+    assertEquals("This is an example . ", rawTextLabels.get(1).getValue());
   }
 
   @Test

--- a/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/AnnisUITest.java
@@ -644,8 +644,9 @@ class AnnisUITest {
     // Wait for label to appear
     awaitCondition(20, () -> _find(rawTextPanel, Label.class).size() == 2, 1000);
     List<Label> rawTextLabels = _find(rawTextPanel, Label.class);
-    assertEquals("Das ist ein Beispielsatz . ", rawTextLabels.get(0).getValue());
-    assertEquals("This is an example . ", rawTextLabels.get(1).getValue());
+    assertEquals("This is an example . ", rawTextLabels.get(0).getValue());
+    assertEquals("Das ist ein Beispielsatz . ", rawTextLabels.get(1).getValue());
+
   }
 
   @Test

--- a/src/test/java/org/corpus_tools/annis/gui/HelperTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/HelperTest.java
@@ -36,6 +36,11 @@ class HelperTest {
     assertEquals(
         "(a#tok | a#pos | a#something | a#annis:node_type=\"datasource\") & doc#annis:node_name=/corpus\\x2Fdoc/ & #a @* #doc",
         Helper.buildDocumentQuery("corpus/doc", Arrays.asList("pos", "something"), true));
+    // Test the node annotation filter with qualified annotation names
+    assertEquals(
+        "(a#tok | a#ns:pos | a#something | a#default:another | a#annis:node_type=\"datasource\") & doc#annis:node_name=/corpus\\x2Fdoc/ & #a @* #doc",
+        Helper.buildDocumentQuery("corpus/doc",
+            Arrays.asList("ns::pos", "something", "default::another"), true));
     // Check invalid node annotation names lead to falling back to the whole document query
     assertEquals(WHOLEDOCUMENT_QUERY,
         Helper.buildDocumentQuery("corpus/doc", Arrays.asList("pos", "myanno=something"), false));

--- a/src/test/java/org/corpus_tools/annis/gui/HelperTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/HelperTest.java
@@ -10,9 +10,9 @@ import org.junit.jupiter.api.Test;
 class HelperTest {
 
   private static final String RAWTEXT_QUERY =
-      "(a#tok) & doc#annis:node_name=/corpus\\x2Fdoc/ & #a @* #doc";
+      "(a#tok | a#annis:node_type=\"datasource\") & doc#annis:node_name=/corpus\\x2Fdoc/ & #a @* #doc";
   private static final String WHOLEDOCUMENT_QUERY =
-      "(n#node) & doc#annis:node_name=/corpus\\x2Fdoc/ & #n @* #doc";
+      "n#annis:node_type & doc#annis:node_name=/corpus\\x2Fdoc/ & #n @* #doc";
 
   @Test
   void testRightToLeft() {
@@ -29,24 +29,23 @@ class HelperTest {
   @Test
   void testBuildAQLDocumentQuery() {
     // Test the full document fallback query
-    assertEquals(WHOLEDOCUMENT_QUERY,
-        Helper.buildDocumentQuery("corpus/doc", null, false));
+    assertEquals(WHOLEDOCUMENT_QUERY, Helper.buildDocumentQuery("corpus/doc", null, false));
     // Test the raw text query
-    assertEquals(RAWTEXT_QUERY,
-        Helper.buildDocumentQuery("corpus/doc", null, true));
+    assertEquals(RAWTEXT_QUERY, Helper.buildDocumentQuery("corpus/doc", null, true));
     // Test the node annotation filter
     assertEquals(
-        "(a#tok | a#pos | a#something) & doc#annis:node_name=/corpus\\x2Fdoc/ & #a @* #doc",
+        "(a#tok | a#pos | a#something | a#annis:node_type=\"datasource\") & doc#annis:node_name=/corpus\\x2Fdoc/ & #a @* #doc",
         Helper.buildDocumentQuery("corpus/doc", Arrays.asList("pos", "something"), true));
-   // Check invalid node annotation names lead to falling back to the whole document query
-   assertEquals(WHOLEDOCUMENT_QUERY,
-       Helper.buildDocumentQuery("corpus/doc", Arrays.asList("pos", "myanno=something"), false));
-   // When giving giving both a node annotation filter argument and using raw text, the node filter
-   // query should be returned
-   assertEquals("(a#tok | a#ns:pos) & doc#annis:node_name=/corpus\\x2Fdoc/ & #a @* #doc",
-       Helper.buildDocumentQuery("corpus/doc", Arrays.asList("ns:pos"), true));
+    // Check invalid node annotation names lead to falling back to the whole document query
+    assertEquals(WHOLEDOCUMENT_QUERY,
+        Helper.buildDocumentQuery("corpus/doc", Arrays.asList("pos", "myanno=something"), false));
+    // When giving giving both a node annotation filter argument and using raw text, the node filter
+    // query should be returned
+    assertEquals(
+        "(a#tok | a#ns:pos | a#annis:node_type=\"datasource\") & doc#annis:node_name=/corpus\\x2Fdoc/ & #a @* #doc",
+        Helper.buildDocumentQuery("corpus/doc", Arrays.asList("ns:pos"), true));
 
-    
+
   }
 
 }

--- a/src/test/java/org/corpus_tools/annis/gui/exporter/TextColumnExporterTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/exporter/TextColumnExporterTest.java
@@ -65,9 +65,10 @@ class TextColumnExporterTest {
     String[] lines = out.toString().split("\n");
     assertEquals(3, lines.length);
     assertEquals("match_number\tspeaker\tleft_context\tmatch_column\tright_context", lines[0]);
-    assertEquals("1\t\t\tFeigenblatt\tDie Jugendlichen in Zossen wollen", lines[1]);
+    assertEquals("1\tmerged.maz-11299.text.xml\t\tFeigenblatt\tDie Jugendlichen in Zossen wollen",
+        lines[1]);
     assertEquals(
-        "2\t\tJugendlichen wurden somit zum bloßen\tFeigenblatt\tdegradiert . Nicht über sondern",
+        "2\tmerged.maz-11299.text.xml\tJugendlichen wurden somit zum bloßen\tFeigenblatt\tdegradiert . Nicht über sondern",
         lines[2]);
   }
 
@@ -88,9 +89,11 @@ class TextColumnExporterTest {
     assertEquals(
         "match_number\tspeaker\tleft_context\tmatch_1\tmiddle_context_1\tmatch_2\tright_context",
         lines[0]);
-    assertEquals("1\t\t\tFeigenblatt\t\tDie\tJugendlichen in Zossen wollen ein", lines[1]);
     assertEquals(
-        "2\t\tJugendlichen wurden somit zum bloßen\tFeigenblatt\t\tdegradiert\t. Nicht über sondern mit",
+        "1\tmerged.maz-11299.text.xml\t\tFeigenblatt\t\tDie\tJugendlichen in Zossen wollen ein",
+        lines[1]);
+    assertEquals(
+        "2\tmerged.maz-11299.text.xml\tJugendlichen wurden somit zum bloßen\tFeigenblatt\t\tdegradiert\t. Nicht über sondern mit",
         lines[2]);
   }
 
@@ -111,9 +114,11 @@ class TextColumnExporterTest {
     assertEquals(3, lines.length);
     assertEquals("match_number\tspeaker\tGenre\tleft_context\tmatch_column\tright_context",
         lines[0]);
-    assertEquals("1\t\tPolitik\t\tFeigenblatt\tDie Jugendlichen in Zossen wollen", lines[1]);
     assertEquals(
-        "2\t\tPolitik\tJugendlichen wurden somit zum bloßen\tFeigenblatt\tdegradiert . Nicht über sondern",
+        "1\tmerged.maz-11299.text.xml\tPolitik\t\tFeigenblatt\tDie Jugendlichen in Zossen wollen",
+        lines[1]);
+    assertEquals(
+        "2\tmerged.maz-11299.text.xml\tPolitik\tJugendlichen wurden somit zum bloßen\tFeigenblatt\tdegradiert . Nicht über sondern",
         lines[2]);
   }
 


### PR DESCRIPTION
Multiple texts in parallel corpora where treated as a single text, causing
several problems. E.g. the KWIC view was showing a single token row with gaps
instead of several token rows for parallel corpora.