### PR TITLE
fixed tree visualization; ignore terminal namespace when null

### DIFF
--- a/src/main/java/org/corpus_tools/annis/gui/visualizers/component/tree/AnnisGraphTools.java
+++ b/src/main/java/org/corpus_tools/annis/gui/visualizers/component/tree/AnnisGraphTools.java
@@ -84,12 +84,11 @@ public class AnnisGraphTools implements Serializable {
     if(input != null) {
       terminalName = input.getMappings().get(TigerTreeVisualizer.TERMINAL_NAME_KEY);
       terminalNamespace = input.getMappings().get(TigerTreeVisualizer.TERMINAL_NS_KEY);
-    }
-
+    }    
     if (terminalName == null) {
       return n instanceof SToken;
     } else {
-      SAnnotation anno = n.getAnnotation(terminalNamespace, terminalName);
+      String anno = extractAnnotation(n.getAnnotations(), terminalNamespace, terminalName);
 
       return anno != null;
     }


### PR DESCRIPTION
The tree visualizer used to fail, when the terminal namespace mapping is not configured, thus null. Null was then matched against the terminal node's actual namespace in ANNIS4. In ANNIS3, though, the namespace for terminals was ignored when the mapping was not configured (i. e. null). This behaviour is now restored.