### PR TITLE
The context defined in the exporter panel was not taken into account.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   items and the segmentation spans become actual SToken. There are several
   corpora that depend on this functionality and where the exporters failed to
   generated proper text spans because of this.
+- The context defined in the exporter panel was not taken into account.
 
 ## [4.9.6] - 2022-09-06
 

--- a/src/main/java/org/corpus_tools/annis/gui/QueryController.java
+++ b/src/main/java/org/corpus_tools/annis/gui/QueryController.java
@@ -449,7 +449,7 @@ public class QueryController implements Serializable {
         .corpora(new LinkedHashSet<>(state.getSelectedCorpora()))
         .queryLanguage(state.getQueryLanguageLegacy()).left(state.getLeftContext())
         .right(state.getRightContext()).segmentation(state.getVisibleBaseText().getValue())
-        .exporter(state.getExporter().getValue())
+        .exporter(state.getExporter())
         .annotations(state.getExportAnnotationKeys().getValue())
         .param(state.getExportParameters().getValue()).alignmc(state.getAlignmc().getValue())
         .build();
@@ -585,7 +585,9 @@ public class QueryController implements Serializable {
       setIfNew(state.getVisibleBaseText(), ((DisplayedResultQuery) q).getBaseText());
     }
     if (q instanceof ExportQuery) {
-      setIfNew(state.getExporter(), ((ExportQuery) q).getExporter());
+      if (!Objects.equals(state.getExporter(), ((ExportQuery) q).getExporter())) {
+        state.setExporter(((ExportQuery) q).getExporter());
+      }
       setIfNew(state.getExportAnnotationKeys(), ((ExportQuery) q).getAnnotationKeys());
       setIfNew(state.getExportParameters(), ((ExportQuery) q).getParameters());
       setIfNew(state.getAlignmc(), ((ExportQuery) q).getAlignmc());

--- a/src/main/java/org/corpus_tools/annis/gui/controlpanel/SearchOptionsPanel.java
+++ b/src/main/java/org/corpus_tools/annis/gui/controlpanel/SearchOptionsPanel.java
@@ -38,12 +38,12 @@ import org.corpus_tools.annis.api.model.Component;
 import org.corpus_tools.annis.api.model.CorpusConfiguration;
 import org.corpus_tools.annis.api.model.FindQuery;
 import org.corpus_tools.annis.api.model.FindQuery.OrderEnum;
+import org.corpus_tools.annis.api.model.QueryLanguage;
 import org.corpus_tools.annis.gui.AnnisUI;
 import org.corpus_tools.annis.gui.Background;
 import org.corpus_tools.annis.gui.Helper;
 import org.corpus_tools.annis.gui.objects.CorpusConfigMap;
 import org.corpus_tools.annis.gui.objects.QueryUIState;
-import org.corpus_tools.annis.api.model.QueryLanguage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -297,6 +297,10 @@ public class SearchOptionsPanel extends FormLayout {
       binder.forField(cbOrder).bind("order");
       binder.forField(cbQueryLanguage).bind(QueryUIState::getQueryLanguage,
           QueryUIState::setQueryLanguage);
+
+      // Make sure all other binded components are also updated
+      cbLeftContext.addSelectionListener(event -> binder.setBean(state));
+      cbRightContext.addSelectionListener(event -> binder.setBean(state));
 
       Background
           .run(new CorpusConfigUpdater(ui, new LinkedHashSet<>(state.getSelectedCorpora()), false));

--- a/src/main/java/org/corpus_tools/annis/gui/objects/QueryUIState.java
+++ b/src/main/java/org/corpus_tools/annis/gui/objects/QueryUIState.java
@@ -28,10 +28,10 @@ import java.util.TreeSet;
 import java.util.concurrent.Future;
 import okhttp3.Call;
 import org.corpus_tools.annis.api.model.FindQuery.OrderEnum;
+import org.corpus_tools.annis.api.model.QueryLanguage;
 import org.corpus_tools.annis.gui.exporter.CSVExporter;
 import org.corpus_tools.annis.gui.exporter.ExporterPlugin;
 import org.corpus_tools.annis.gui.frequency.UserGeneratedFrequencyEntry;
-import org.corpus_tools.annis.api.model.QueryLanguage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,8 +71,7 @@ public class QueryUIState implements Serializable {
   private final ObjectProperty<Set<Long>> selectedMatches =
       new ObjectProperty<Set<Long>>(new TreeSet<Long>());
 
-  private final ObjectProperty<Class<? extends ExporterPlugin>> exporter =
-      new ObjectProperty<Class<? extends ExporterPlugin>>(CSVExporter.class);
+  private Class<? extends ExporterPlugin> exporter = CSVExporter.class;
   private final ObjectProperty<List<String>> exportAnnotationKeys =
       new ObjectProperty<List<String>>(new ArrayList<String>());
   private final ObjectProperty<String> exportParameters = new ObjectProperty<>("");
@@ -120,8 +119,12 @@ public class QueryUIState implements Serializable {
     return exportAnnotationKeys;
   }
 
-  public ObjectProperty<Class<? extends ExporterPlugin>> getExporter() {
+  public Class<? extends ExporterPlugin> getExporter() {
     return exporter;
+  }
+
+  public void setExporter(Class<? extends ExporterPlugin> exporter) {
+    this.exporter = exporter;
   }
 
   public ObjectProperty<String> getExportParameters() {

--- a/src/test/java/org/corpus_tools/annis/gui/ExportPanelTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/ExportPanelTest.java
@@ -2,12 +2,16 @@ package org.corpus_tools.annis.gui;
 
 import static com.github.mvysny.kaributesting.v8.LocatorJ._click;
 import static com.github.mvysny.kaributesting.v8.LocatorJ._get;
+import static com.github.mvysny.kaributesting.v8.LocatorJ._setValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.github.mvysny.kaributesting.v8.MockVaadin;
 import com.google.common.collect.Sets;
 import com.vaadin.spring.internal.UIScopeImpl;
 import com.vaadin.ui.Button;
+import com.vaadin.ui.ComboBox;
+import org.corpus_tools.annis.gui.controlpanel.SearchOptionsPanel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,6 +66,59 @@ class ExportPanelTest {
     // enabled
     _click(_get(panel, Button.class, spec -> spec.withCaption("Perform Export")));
     TestHelper.awaitCondition(30, downloadButton::isEnabled);
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @Test
+  void testTextColumnExportContextChange() throws Exception {
+    // Prepare query
+    ui.getQueryController().setQuery(
+        QueryGenerator.displayed().corpora(Sets.newHashSet("pcc2")).query("pos=\"NE\"").build());
+
+    // Click on the "More" button and then "Export"
+    PopupButton moreButton = _get(PopupButton.class, spec -> spec.withCaption("More"));
+    moreButton.setPopupVisible(true);
+    _click(_get(Button.class, spec -> spec.withCaption("Export")));
+
+    // Make sure the Export tab is there
+    ExportPanel panel = _get(ExportPanel.class);
+
+    // Change to text column exporter
+    ComboBox exporterSelection = _get(panel, ComboBox.class, spec -> spec.withCaption("Exporter"));
+    _setValue(exporterSelection, "TextColumnExporter");
+
+    // Get the search options panel that should be in sync
+    SearchOptionsPanel searchOptions = _get(SearchOptionsPanel.class);
+
+    // Check that the initial values are correct
+    ComboBox leftContextExportPanel =
+        _get(panel, ComboBox.class, spec -> spec.withCaption("Left Context"));
+    ComboBox rightContextExportPanel =
+        _get(panel, ComboBox.class, spec -> spec.withCaption("Right Context"));
+    assertEquals(leftContextExportPanel.getValue(), 5);
+    assertEquals(rightContextExportPanel.getValue(), 5);
+
+    ComboBox leftContextSearchOptions =
+        _get(searchOptions, ComboBox.class, spec -> spec.withCaption("Left Context"));
+    ComboBox rightContextSearchOptions =
+        _get(searchOptions, ComboBox.class, spec -> spec.withCaption("Right Context"));
+    assertEquals(leftContextSearchOptions.getValue(), 5);
+    assertEquals(rightContextSearchOptions.getValue(), 5);
+
+    assertEquals(ui.getQueryState().getLeftContext(), 5);
+    assertEquals(ui.getQueryState().getRightContext(), 5);
+
+    // Change the value of the combo boxes and test that the query state and the search panel
+    // options have changed
+    _setValue(leftContextExportPanel, 10);
+    _setValue(rightContextExportPanel, 20);
+
+    assertEquals(ui.getQueryState().getLeftContext(), 10);
+    assertEquals(ui.getQueryState().getRightContext(), 20);
+    assertEquals(leftContextSearchOptions.getValue(), 10);
+    assertEquals(rightContextSearchOptions.getValue(), 20);
+
+
 
   }
 


### PR DESCRIPTION
We now synchronize the left/right context in the exporter panel and the one in the search options. Since this is doubled functionality, we might also consider to remove the left/right context in the exporter at some time. But having it synchronized seems less confusing than having two states.