### PR TITLE
Do not use decoded corpus/document name as Salt ID.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix display of match path in results that match a document or corpus (metadata
+  search) and the corpus has a special character like an umlaut.
+
 ## [4.9.7] - 2022-09-22
 
 ### Fixed

--- a/src/main/java/org/corpus_tools/annis/gui/EmbeddedVisUI.java
+++ b/src/main/java/org/corpus_tools/annis/gui/EmbeddedVisUI.java
@@ -218,7 +218,7 @@ public class EmbeddedVisUI extends CommonUI {
     CorporaApi api = new CorporaApi(client);
     Match match = Match.parseFromString(args.get(KEY_MATCH)[0]);
     String matchId = match.getSaltIDs().get(0);
-    List<String> corpusPathRaw = Helper.getCorpusPath(matchId, true);
+    List<String> corpusPathRaw = Helper.getCorpusPath(matchId, false);
     List<String> corpusPathDecoded = Helper.getCorpusPath(matchId, true);
     String toplevelCorpus = corpusPathDecoded.get(0);
     String corpusNodeId = Joiner.on('/').join(corpusPathRaw);

--- a/src/main/java/org/corpus_tools/annis/gui/resultfetch/ResultFetchJob.java
+++ b/src/main/java/org/corpus_tools/annis/gui/resultfetch/ResultFetchJob.java
@@ -186,22 +186,23 @@ public class ResultFetchJob implements Runnable {
 
   private SaltProject createSaltFromMatch(Match m, SubgraphWithContext arg, int currentMatchNumber,
       CorporaApi api) throws ApiException {
-    List<String> corpusPath = Helper.getCorpusPath(m.getSaltIDs().get(0));
+    List<String> corpusPathRaw = Helper.getCorpusPath(m.getSaltIDs().get(0), false);
+    List<String> corpusPathDecoded = Helper.getCorpusPath(m.getSaltIDs().get(0), true);
     final SaltProject p = SaltFactory.createSaltProject();
 
-    if (!corpusPath.isEmpty()) {
-      File graphML = api.subgraphForNodes(corpusPath.get(0), arg);
+    if (!corpusPathRaw.isEmpty()) {
+      File graphML = api.subgraphForNodes(corpusPathDecoded.get(0), arg);
       try {
 
         final SCorpusGraph cg = p.createCorpusGraph();
-        URI docURI = URI.createURI("salt:/" + Joiner.on('/').join(corpusPath));
-        if (corpusPath.size() > 1) {
+        URI docURI = URI.createURI("salt:/" + Joiner.on('/').join(corpusPathRaw));
+        if (corpusPathRaw.size() > 1) {
           SDocument doc = cg.createDocument(docURI);
           SDocumentGraph docGraph = DocumentGraphMapper.map(graphML);
           doc.setDocumentGraph(docGraph);
           Helper.addMatchToDocumentGraph(m, doc.getDocumentGraph());
-        } else if (corpusPath.size() == 1) {
-          cg.createCorpus(null, corpusPath.get(0));
+        } else if (corpusPathRaw.size() == 1) {
+          cg.createCorpus(null, corpusPathRaw.get(0));
         }
         log.debug("added match {} to queue", currentMatchNumber + 1);
       } catch (XMLStreamException | IOException ex) {

--- a/src/main/java/org/corpus_tools/annis/gui/resultview/ResolverProvider.java
+++ b/src/main/java/org/corpus_tools/annis/gui/resultview/ResolverProvider.java
@@ -24,6 +24,6 @@ import org.corpus_tools.salt.common.SDocument;
  * @author thomas
  */
 public interface ResolverProvider extends Serializable {
-  public List<VisualizerRule> getResolverEntries(SDocument result, UI ui);
+  public List<VisualizerRule> getResolverEntries(String corpusName, SDocument result, UI ui);
 
 }

--- a/src/main/java/org/corpus_tools/annis/gui/resultview/ResolverProviderImpl.java
+++ b/src/main/java/org/corpus_tools/annis/gui/resultview/ResolverProviderImpl.java
@@ -54,7 +54,7 @@ public class ResolverProviderImpl implements ResolverProvider, Serializable {
   }
 
   @Override
-  public List<VisualizerRule> getResolverEntries(SDocument doc, UI ui) {
+  public List<VisualizerRule> getResolverEntries(String corpusName, SDocument doc, UI ui) {
 
 
     // create a request for resolver entries
@@ -81,8 +81,6 @@ public class ResolverProviderImpl implements ResolverProvider, Serializable {
       }
 
     }
-
-    String corpusName = doc.getGraph().getRoots().get(0).getName();
 
     for (String ns : nodeLayers) {
       resolverRequests.add(new SingleResolverRequest(corpusName, ns, ElementEnum.NODE));

--- a/src/main/java/org/corpus_tools/annis/gui/resultview/SingleResultPanel.java
+++ b/src/main/java/org/corpus_tools/annis/gui/resultview/SingleResultPanel.java
@@ -226,7 +226,7 @@ public class SingleResultPanel extends CssLayout
     /**
      * Extract the top level corpus name and the document name of this single result.
      */
-    path = Helper.getCorpusPath(result.getGraph(), result);
+    path = Helper.getCorpusPath(result.getGraph(), result, true);
     Collections.reverse(path);
     // Escape all parts of the corpus path to make it safe to render as HTML
     List<String> escapedPaths =
@@ -371,7 +371,7 @@ public class SingleResultPanel extends CssLayout
   private void initVisualizer() {
     try {
       resolverEntries = resolverProvider == null ? new LinkedList<>()
-          : resolverProvider.getResolverEntries(result, UI.getCurrent());
+          : resolverProvider.getResolverEntries(path.get(0), result, UI.getCurrent());
       visualizers.clear();
 
       List<VisualizerPanel> openVisualizers = new LinkedList<>();


### PR DESCRIPTION
Fixes display of match path in results that match a document or corpus (metadata search) and the corpus has a special character like an umlaut.