### PR TITLE
Do not overwrite existing `service.toml` file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix display of match path in results that match a document or corpus (metadata
   search) and the corpus has a special character like an umlaut.
+- Do not overwrite existing `service.toml` file (which might get the file
+  corrupted in certain cases) but always write the updated configuration to a
+  temporary TOML-file.
 
 ## [4.9.7] - 2022-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not overwrite existing `service.toml` file (which might get the file
   corrupted in certain cases) but always write the updated configuration to a
   temporary TOML-file.
+- Update Apache `commons-text` dependency to >= 1.0 because of of CVE-2022-42889
 
 ## [4.9.7] - 2022-09-22
 

--- a/pom.xml
+++ b/pom.xml
@@ -593,7 +593,7 @@
 		  <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.9</version>
+            <version>[1.10.0,)</version>
             <scope>compile</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -572,15 +572,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.moandjiezana.toml</groupId>
-			<artifactId>toml4j</artifactId>
-			<version>0.7.2</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.tomlj</groupId>
-			<artifactId>tomlj</artifactId>
-			<version>1.0.0</version>
+		    <groupId>com.fasterxml.jackson.dataformat</groupId>
+		    <artifactId>jackson-dataformat-toml</artifactId>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
@@ -55,7 +55,7 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
   private final static Logger log = LoggerFactory.getLogger(ServiceStarter.class);
 
   @Autowired
-  private UIConfig config;
+  protected UIConfig config;
 
   @Autowired
   private ResourceLoader resourceLoader;
@@ -195,9 +195,9 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
   }
 
 
-  protected String getServiceURL(Map<?, ?> config) {
+  protected String getServiceURL(Map<?, ?> serviceConfig) {
     long port = 5711l;
-    Object bindSection = config.get("bind");
+    Object bindSection = serviceConfig.get("bind");
     if (bindSection instanceof Map) {
       @SuppressWarnings("rawtypes")
       Object portRaw = ((Map) bindSection).get("port");

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
@@ -217,23 +217,23 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
     boolean writeTemporaryConfigFile = false;
 
     // Read existing file or create empty configuration
-    final Map<Object, Object> config;
+    final Map<Object, Object> serviceConfig;
     if (existingConfigFile.exists()) {
-      config = mapper.readValue(existingConfigFile, Map.class);
+      serviceConfig = mapper.readValue(existingConfigFile, Map.class);
     } else {
-      config = new LinkedHashMap<>();
+      serviceConfig = new LinkedHashMap<>();
       writeTemporaryConfigFile = true;
     }
 
     // Set to a default data folder and SQLite file
-    Object databaseConfigRaw = config.get(DATABASE_SECTION);
+    Object databaseConfigRaw = serviceConfig.get(DATABASE_SECTION);
     final Map<Object, Object> databaseConfig;
     if (databaseConfigRaw instanceof Map) {
       databaseConfig = (Map<Object, Object>) databaseConfigRaw;
     } else {
       // Create a new map instead of re-using the existing one
       databaseConfig = new LinkedHashMap<>();
-      config.put(DATABASE_SECTION, databaseConfig);
+      serviceConfig.put(DATABASE_SECTION, databaseConfig);
       writeTemporaryConfigFile = true;
     }
     // Add the graphannis data and sqlite location of not existing yet
@@ -254,13 +254,13 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
     }
 
     // Change service debug level if ANNIS itself is in debug mode
-    Object loggingConfigRaw = config.get(LOGGING_SECTION);
+    Object loggingConfigRaw = serviceConfig.get(LOGGING_SECTION);
     final Map<Object, Object> loggingConfig;
     if (loggingConfigRaw instanceof Map) {
       loggingConfig = (Map<Object, Object>) loggingConfigRaw;
     } else {
       loggingConfig = new LinkedHashMap<>();
-      config.put(LOGGING_SECTION, loggingConfig);
+      serviceConfig.put(LOGGING_SECTION, loggingConfig);
     }
     Object debugConfigRaw = loggingConfig.get("debug");
     if (!Objects.equal(debugConfigRaw, log.isDebugEnabled())) {
@@ -281,7 +281,7 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
         log.info("Writing default service configuration file to {}",
             tmpConfigFile.getAbsolutePath());
       }
-      mapper.writeValue(tmpConfigFile, config);
+      mapper.writeValue(tmpConfigFile, serviceConfig);
       return tmpConfigFile;
     } else {
       // Return the original configuration file, which did not need to be changed

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
@@ -83,6 +83,7 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
     config.put("auth", auth);
 
     File temporaryFile = File.createTempFile("annis-service-config-desktop-", ".toml");
+    temporaryFile.deleteOnExit();
     mapper.writeValue(temporaryFile, config);
     return temporaryFile;
   }

--- a/src/test/java/org/corpus_tools/annis/gui/ServiceStarterDesktopTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/ServiceStarterDesktopTest.java
@@ -7,9 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.mvysny.kaributesting.v8.MockVaadin;
 import com.vaadin.spring.internal.UIScopeImpl;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,8 +18,7 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.web.WebAppConfiguration;
-import org.tomlj.Toml;
-import org.tomlj.TomlParseResult;
+
 
 @SpringBootTest
 @ActiveProfiles({"desktop", "test", "headless"})
@@ -61,32 +57,5 @@ class ServiceStarterDesktopTest {
     assertTrue(auth.getPrincipal() instanceof OAuth2User);
   }
 
-  @Test
-  void testUnpackToml() {
-    TomlParseResult toml = Toml.parse(
-        "[main]\n" + "test =\"value\"\n" + "b = [42, 23]\n" + "nested_array = [[1,2]]");
-    Map<String, Object> unpacked = ServiceStarterDesktop.unpackToml(toml);
-
-    assertEquals(1, unpacked.size());
-    assertTrue(unpacked.get("main") instanceof Map);
-    @SuppressWarnings("unchecked")
-    Map<String, Object> main = (Map<String, Object>) unpacked.get("main");
-    assertEquals(3, main.size());
-
-    assertEquals("value", main.get("test"));
-    assertTrue(main.get("b") instanceof List);
-    @SuppressWarnings("unchecked")
-    List<Object> b = (List<Object>) main.get("b");
-    assertEquals(2, b.size());
-    assertEquals(42l, b.get(0));
-    assertEquals(23l, b.get(1));
-
-    assertTrue(main.get("nested_array") instanceof List);
-    @SuppressWarnings("unchecked")
-    List<Object> nestedArray = (List<Object>) main.get("nested_array");
-    assertEquals(1, nestedArray.size());
-    assertTrue(nestedArray.get(0) instanceof List);
-    assertEquals(Arrays.asList(1l, 2l), nestedArray.get(0));
-  }
 
 }

--- a/src/test/java/org/corpus_tools/annis/gui/ServiceStarterTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/ServiceStarterTest.java
@@ -1,0 +1,132 @@
+package org.corpus_tools.annis.gui;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.util.ResourceUtils;
+
+
+@SpringBootTest
+@ActiveProfiles({"test", "headless"})
+@WebAppConfiguration
+class ServiceStarterTest {
+
+  @Autowired
+  private BeanFactory beanFactory;
+
+  private ServiceStarter service;
+
+  @BeforeEach
+  public void setup() {
+    service = beanFactory.getBean(ServiceStarter.class);
+  }
+
+
+  @Test
+  void testNonExistingServiceConfig() throws IOException {
+
+    File serviceConfig = new File("./this-file-does-not-exist.toml");
+    service.config.setWebserviceConfig(serviceConfig.getAbsolutePath());
+
+    File resultFile = service.getServiceConfig();
+
+    // The file should be a newly created one
+    assertNotEquals(serviceConfig, resultFile);
+
+    List<String> resultContent = Files.readAllLines(resultFile.toPath());
+    Collections.sort(resultContent);
+
+    // Check that the file content are the default values
+    assertEquals(3, resultContent.size());
+    assertTrue(resultContent.get(0).startsWith("database.graphannis = '"));
+    assertTrue(resultContent.get(0).endsWith("/.annis/v4'"));
+
+    assertTrue(resultContent.get(1).startsWith("database.sqlite = '"));
+    assertTrue(resultContent.get(1).endsWith("/.annis/v4/service_data.sqlite3'"));
+
+    assertEquals("logging.debug = true", resultContent.get(2));
+  }
+
+  @Test
+  void testOverwriteGraphannisLocation() throws IOException {
+    File serviceConfig =
+        ResourceUtils.getFile(this.getClass().getResource("overwritten-graphannis-location.toml"));
+    service.config.setWebserviceConfig(serviceConfig.getAbsolutePath());
+
+    File resultFile = service.getServiceConfig();
+
+    // The file should be a newly created one
+    assertNotEquals(serviceConfig, resultFile);
+
+    List<String> resultContent = Files.readAllLines(resultFile.toPath());
+    Collections.sort(resultContent);
+
+    // Check that the file content are the default values, except for the graphANNIS location
+    assertEquals(3, resultContent.size());
+    assertEquals("database.graphannis = '/tmp/this-is-a-test'", resultContent.get(0));
+
+    assertTrue(resultContent.get(1).startsWith("database.sqlite = '"));
+    assertTrue(resultContent.get(1).endsWith("/.annis/v4/service_data.sqlite3'"));
+
+    assertEquals("logging.debug = true", resultContent.get(2));
+  }
+
+  @Test
+  void testOverwriteSqliteLocation() throws IOException {
+    File serviceConfig =
+        ResourceUtils.getFile(this.getClass().getResource("overwritten-sqlite-location.toml"));
+    service.config.setWebserviceConfig(serviceConfig.getAbsolutePath());
+
+    File resultFile = service.getServiceConfig();
+
+    // The file should be a newly created one
+    assertNotEquals(serviceConfig, resultFile);
+
+    List<String> resultContent = Files.readAllLines(resultFile.toPath());
+    Collections.sort(resultContent);
+
+    // Check that the file content are the default values, except for the sqlite location
+    assertEquals(3, resultContent.size());
+
+    assertTrue(resultContent.get(0).startsWith("database.graphannis = '"));
+    assertTrue(resultContent.get(0).endsWith("/.annis/v4'"));
+
+    assertEquals("database.sqlite = '/tmp/this-is-a-test'", resultContent.get(1));
+
+    assertEquals("logging.debug = true", resultContent.get(2));
+  }
+
+  @Test
+  void testEnableDebugLogging() throws IOException {
+    File serviceConfig =
+        ResourceUtils.getFile(this.getClass().getResource("debug-disabled.toml"));
+
+    service.config.setWebserviceConfig(serviceConfig.getAbsolutePath());
+
+    File resultFile = service.getServiceConfig();
+
+    // The file should be a newly created one
+    assertNotEquals(serviceConfig, resultFile);
+
+    List<String> resultContent = Files.readAllLines(resultFile.toPath());
+    Collections.sort(resultContent);
+
+    // Check that the debug value has been overwritten
+    assertEquals(3, resultContent.size());
+    assertEquals("logging.debug = true", resultContent.get(2));
+
+  }
+}

--- a/src/test/resources/org/corpus_tools/annis/gui/debug-disabled.toml
+++ b/src/test/resources/org/corpus_tools/annis/gui/debug-disabled.toml
@@ -1,0 +1,2 @@
+[logging]
+debug = false

--- a/src/test/resources/org/corpus_tools/annis/gui/overwritten-graphannis-location.toml
+++ b/src/test/resources/org/corpus_tools/annis/gui/overwritten-graphannis-location.toml
@@ -1,0 +1,1 @@
+database.graphannis = '/tmp/this-is-a-test'

--- a/src/test/resources/org/corpus_tools/annis/gui/overwritten-sqlite-location.toml
+++ b/src/test/resources/org/corpus_tools/annis/gui/overwritten-sqlite-location.toml
@@ -1,0 +1,1 @@
+database.sqlite = '/tmp/this-is-a-test'


### PR DESCRIPTION
Instead, always use an new temporary service configuration file when the config needs to be updated by the front-end. There have been some problems with corrupted ~/.annis/service.toml files, that where probably caused by not unpacking the parsed TOML tables. By using the more robust jackson-dataformat-toml library and only write to new files instead of updating the existing file, this corruption should not occure any more.