### PR TITLE
Decode corpus names in Helper#getToplevelCorpusNames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue with corpus names containing special characters when login is
+  active. There was a "Forbidden" error when trying to access the corpus
+  configuration.
+
 ## [4.9.8] - 2022-10-22
 
 ### Fixed

--- a/src/main/java/org/corpus_tools/annis/gui/Helper.java
+++ b/src/main/java/org/corpus_tools/annis/gui/Helper.java
@@ -1094,15 +1094,19 @@ public class Helper {
    *
    * @param p Salt project
    * @return returns an empty list if project is empty or null.
+   * @throws UnsupportedEncodingException
    */
-  public static Set<String> getToplevelCorpusNames(final SaltProject p) {
+  public static Set<String> getToplevelCorpusNames(final SaltProject p)
+      throws UnsupportedEncodingException {
     final Set<String> names = new HashSet<>();
 
     if (p != null && p.getCorpusGraphs() != null) {
       for (final SCorpusGraph g : p.getCorpusGraphs()) {
         if (g.getRoots() != null) {
           for (final SNode c : g.getRoots()) {
-            names.add(c.getName());
+            String rawName = c.getName();
+            String decodedName = URLDecoder.decode(rawName, UTF_8);
+            names.add(decodedName);
           }
         }
       }

--- a/src/main/java/org/corpus_tools/annis/gui/exporter/ExportHelper.java
+++ b/src/main/java/org/corpus_tools/annis/gui/exporter/ExportHelper.java
@@ -5,6 +5,7 @@ import static org.corpus_tools.annis.api.model.CorpusConfigurationViewTimelineSt
 import com.google.common.base.Joiner;
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -50,7 +51,8 @@ public class ExportHelper {
   }
 
   private static void recreateTimelineIfNecessary(SaltProject p, CorporaApi corporaApi,
-      Map<String, CorpusConfiguration> corpusConfigs) throws ApiException {
+      Map<String, CorpusConfiguration> corpusConfigs)
+      throws ApiException, UnsupportedEncodingException {
 
 
     Set<String> corpusNames = Helper.getToplevelCorpusNames(p);

--- a/src/main/java/org/corpus_tools/annis/gui/resultview/ResultViewPanel.java
+++ b/src/main/java/org/corpus_tools/annis/gui/resultview/ResultViewPanel.java
@@ -25,6 +25,7 @@ import com.vaadin.ui.Panel;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.themes.ValoTheme;
+import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -433,7 +434,7 @@ public class ResultViewPanel extends VerticalLayout {
     } // end iterate for segmentation layer
   }
 
-  private void updateVariables(SaltProject p) {
+  private void updateVariables(SaltProject p) throws UnsupportedEncodingException {
     segmentationLayerSet.addAll(getSegmentationNames(p));
     tokenAnnotationLevelSet.addAll(Helper.getTokenAnnotationLevelSet(p));
     Set<String> hiddenTokenAnnos = null;


### PR DESCRIPTION
Since the Salt node names are now not decoded (b526b634), this must be done later when using the node names as basis for the corpus name.