### PR TITLE
Allow execution on macOS with Apple Silicon (M1/M2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show informative error message when segmentation in export does not exist
   instead of a generic stack trace
 
+### Fixed
+
+- Allow execution on macOS with Apple Silicon (M1/M2) using the Rosetta
+  emulation when starting the graphANNIS service process
+
 ## [4.9.9] - 2022-10-26
 
 ### Fixed

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
@@ -117,8 +117,21 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
           // Start the process and read output/error stream in background threads
           log.info("Starting the bundled graphANNIS service with configuration file {}",
               serviceConfigFile.getAbsolutePath());
-          backgroundProcess = new ProcessBuilder(tmpExec.getAbsolutePath(), "--config",
-              serviceConfigFile.getAbsolutePath()).start();
+          ProcessBuilder backgroundProcessBuilder;
+
+          if (SystemUtils.IS_OS_MAC_OSX) {
+            // On MacOS has several processor architectors, but allows to emulate x86_64 processors
+            // with the Rosetta tool. We use the `arch` helper program to trigger emulation if
+            // necessary. This is necessary when Java support the native processor architecture and
+            // thus is not emulated yet.
+            backgroundProcessBuilder = new ProcessBuilder("arch", "-arch x86_64",
+                tmpExec.getAbsolutePath(), "--config", serviceConfigFile.getAbsolutePath());
+
+          } else {
+            backgroundProcessBuilder = new ProcessBuilder(tmpExec.getAbsolutePath(), "--config",
+                serviceConfigFile.getAbsolutePath());
+          }
+          backgroundProcess = backgroundProcessBuilder.start();
 
           // Create threads that read from the output and error streams and add the messages to
           // our log

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarter.java
@@ -124,7 +124,7 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
             // with the Rosetta tool. We use the `arch` helper program to trigger emulation if
             // necessary. This is necessary when Java support the native processor architecture and
             // thus is not emulated yet.
-            backgroundProcessBuilder = new ProcessBuilder("arch", "-arch x86_64",
+            backgroundProcessBuilder = new ProcessBuilder("arch", "-x86_64",
                 tmpExec.getAbsolutePath(), "--config", serviceConfigFile.getAbsolutePath());
 
           } else {
@@ -160,11 +160,11 @@ public class ServiceStarter implements ApplicationListener<ApplicationReadyEvent
    */
   private Optional<String> executablePathForSystem() {
     Optional<String> execPath = Optional.empty();
-    if ("amd64".equals(SystemUtils.OS_ARCH) || "x86_64".equals(SystemUtils.OS_ARCH)) {
+    if (SystemUtils.IS_OS_MAC_OSX) {
+      execPath = Optional.of("darwin/graphannis-webservice.osx");
+    } else if ("amd64".equals(SystemUtils.OS_ARCH) || "x86_64".equals(SystemUtils.OS_ARCH)) {
       if (SystemUtils.IS_OS_LINUX) {
         execPath = Optional.of("linux-x86-64/graphannis-webservice");
-      } else if (SystemUtils.IS_OS_MAC_OSX) {
-        execPath = Optional.of("darwin/graphannis-webservice.osx");
       } else if (SystemUtils.IS_OS_WINDOWS) {
         execPath = Optional.of("win32-x86-64/graphannis-webservice.exe");
       }

--- a/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
+++ b/src/main/java/org/corpus_tools/annis/gui/ServiceStarterDesktop.java
@@ -177,16 +177,6 @@ public class ServiceStarterDesktop extends ServiceStarter { // NO_UCD (unused co
           webURL);
     } else if ("amd64".equals(SystemUtils.OS_ARCH) || "x86_64".equals(SystemUtils.OS_ARCH)
         || SystemUtils.IS_OS_MAC_OSX) {
-      if (SystemUtils.IS_OS_MAC_OSX && "aarch64".equals(SystemUtils.OS_ARCH)) {
-        // Show warning, but still run ANNIS
-        JOptionPane.showMessageDialog(null,
-            "ANNIS is not tested on Apple M1 systems yet!\n"
-                + "It is prefered to use the Rosetta emulator,\n"
-                + "but your version of Java uses the M1 processor natively.\n\n"
-                + "You can try to install and use the Adoptium OpenJDK Java Version 11\n"
-                + "from https://adoptium.net to run ANNIS and make sure Rosetta is used.",
-            "ANNIS not tested on MacOS with M1 processor", JOptionPane.WARNING_MESSAGE);
-      }
       showApplicationWindow();
       openBrowser(webURL);
     } else {


### PR DESCRIPTION
It uses the Rosetta emulation when starting the graphANNIS service process regardless of the architecture the Java VM is started onl.