### PR TITLE
Refactor JWT Token renewal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Long running exports could fail when you are logged in and the internal token
+  expired. The communication with the REST webservice has been refactored to
+  always get the newest token (automatically refreshed by spring) before
+  executing the call.
+
 ## [4.10.0] - 2022-11-03
 
 ### Added

--- a/src/main/java/org/corpus_tools/annis/gui/AnnisUI.java
+++ b/src/main/java/org/corpus_tools/annis/gui/AnnisUI.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import javax.servlet.ServletContext;
+import org.corpus_tools.annis.ApiClient;
 import org.corpus_tools.annis.api.model.CorpusConfiguration;
 import org.corpus_tools.annis.gui.admin.AdminView;
 import org.corpus_tools.annis.gui.components.ExceptionDialog;
@@ -44,6 +45,7 @@ import org.corpus_tools.annis.gui.query_references.UrlShortener;
 import org.corpus_tools.annis.gui.querybuilder.QueryBuilderPlugin;
 import org.corpus_tools.annis.gui.requesthandler.BinaryRequestHandler;
 import org.corpus_tools.annis.gui.security.AuthenticationSuccessListener;
+import org.corpus_tools.annis.gui.security.AutoTokenRefreshClient;
 import org.corpus_tools.annis.gui.security.SecurityConfiguration;
 import org.corpus_tools.annis.gui.visualizers.VisualizerPlugin;
 import org.slf4j.LoggerFactory;
@@ -258,9 +260,10 @@ public class AnnisUI extends CommonUI implements ErrorHandler, ViewChangeListene
   }
 
   @Override
-  protected String getLastAccessToken() {
-    return authListener.getToken();
+  public ApiClient getClient() {
+    return new AutoTokenRefreshClient(this, this.getAuthListener());
   }
+
 
   public UIConfig getConfig() {
     return config;
@@ -315,5 +318,9 @@ public class AnnisUI extends CommonUI implements ErrorHandler, ViewChangeListene
   @Override
   public OAuth2ClientProperties getOauth2ClientProperties() {
     return this.oauth2Clients;
+  }
+
+  public AuthenticationSuccessListener getAuthListener() {
+    return authListener;
   }
 }

--- a/src/main/java/org/corpus_tools/annis/gui/CommonUI.java
+++ b/src/main/java/org/corpus_tools/annis/gui/CommonUI.java
@@ -23,8 +23,6 @@ import java.util.Optional;
 import javax.servlet.ServletContext;
 import org.corpus_tools.annis.ApiClient;
 import org.corpus_tools.annis.ApiException;
-import org.corpus_tools.annis.Configuration;
-import org.corpus_tools.annis.auth.HttpBearerAuth;
 import org.corpus_tools.annis.gui.components.SettingsStorage;
 import org.corpus_tools.annis.gui.requesthandler.ResourceRequestHandler;
 import org.corpus_tools.annis.gui.security.AuthenticationSuccessListener;
@@ -35,7 +33,6 @@ import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2Clien
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 
 /**
  *
@@ -176,27 +173,9 @@ public abstract class CommonUI extends AnnisBaseUI {
         return urlPrefix;
     }
     
-    protected abstract String getLastAccessToken();
+    public abstract ApiClient getClient();
 
-    public ApiClient getClient() {
-      
-      final ApiClient client = Configuration.getDefaultApiClient().setReadTimeout(0);
-      // Use the configuration to allow changing the path to the web-service
-      client.setBasePath(getConfig().getWebserviceUrl());
 
-      final Optional<OAuth2User> user = Helper.getUser(getSecurityContext());
-      String bearerToken = null;
-      if (user.isPresent()) {
-        bearerToken = getLastAccessToken();
-      }
-      final org.corpus_tools.annis.auth.Authentication auth =
-          client.getAuthentication("bearerAuth");
-      if (auth instanceof HttpBearerAuth) {
-        final HttpBearerAuth bearerAuth = (HttpBearerAuth) auth;
-        bearerAuth.setBearerToken(bearerToken);
-      }
-      return client;
-    }
 
     /**
      * Handle common errors like database/service connection problems and display a unified error

--- a/src/main/java/org/corpus_tools/annis/gui/EmbeddedVisUI.java
+++ b/src/main/java/org/corpus_tools/annis/gui/EmbeddedVisUI.java
@@ -58,6 +58,7 @@ import org.corpus_tools.annis.gui.graphml.DocumentGraphMapper;
 import org.corpus_tools.annis.gui.objects.Match;
 import org.corpus_tools.annis.gui.objects.RawTextWrapper;
 import org.corpus_tools.annis.gui.security.AuthenticationSuccessListener;
+import org.corpus_tools.annis.gui.security.AutoTokenRefreshClient;
 import org.corpus_tools.annis.gui.util.ANNISFontIcon;
 import org.corpus_tools.annis.gui.visualizers.VisualizerInput;
 import org.corpus_tools.annis.gui.visualizers.VisualizerPlugin;
@@ -495,9 +496,10 @@ public class EmbeddedVisUI extends CommonUI {
   }
   
   @Override
-  protected String getLastAccessToken() {
-      return authListener.getToken();
+  public ApiClient getClient() {
+    return new AutoTokenRefreshClient(this, this.authListener);
   }
+
 
   @Override
   public ServletContext getServletContext() {

--- a/src/main/java/org/corpus_tools/annis/gui/UnsupportedQueryUI.java
+++ b/src/main/java/org/corpus_tools/annis/gui/UnsupportedQueryUI.java
@@ -21,7 +21,9 @@ import com.vaadin.ui.Button;
 import com.vaadin.ui.Panel;
 import com.vaadin.ui.declarative.Design;
 import javax.servlet.ServletContext;
+import org.corpus_tools.annis.ApiClient;
 import org.corpus_tools.annis.gui.security.AuthenticationSuccessListener;
+import org.corpus_tools.annis.gui.security.AutoTokenRefreshClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 
@@ -127,7 +129,7 @@ public class UnsupportedQueryUI extends CommonUI { // NO_UCD (test only)
   }
   
   @Override
-  protected String getLastAccessToken() {
-      return authListener.getToken();
+  public ApiClient getClient() {
+    return new AutoTokenRefreshClient(this, this.authListener);
   }
 }

--- a/src/main/java/org/corpus_tools/annis/gui/security/AutoTokenRefreshClient.java
+++ b/src/main/java/org/corpus_tools/annis/gui/security/AutoTokenRefreshClient.java
@@ -1,0 +1,53 @@
+package org.corpus_tools.annis.gui.security;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+import okhttp3.Call;
+import org.corpus_tools.annis.ApiCallback;
+import org.corpus_tools.annis.ApiClient;
+import org.corpus_tools.annis.ApiException;
+import org.corpus_tools.annis.ApiResponse;
+import org.corpus_tools.annis.gui.CommonUI;
+import org.corpus_tools.annis.gui.Helper;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public class AutoTokenRefreshClient extends ApiClient {
+
+  private final AuthenticationSuccessListener authListener;
+  private final CommonUI ui;
+
+  public AutoTokenRefreshClient(CommonUI ui, AuthenticationSuccessListener authListener) {
+    super();
+    this.ui = ui;
+    this.authListener = authListener;
+
+    setReadTimeout(0);
+
+    // Use the configuration to allow changing the path to the web-service
+    setBasePath(ui.getConfig().getWebserviceUrl());
+
+
+    updateToken();
+  }
+
+  private void updateToken() {
+    final Optional<OAuth2User> user = Helper.getUser(ui.getSecurityContext());
+    if (user.isPresent()) {
+      setBearerToken(authListener.getToken());
+    } else {
+      setBearerToken(null);
+    }
+  }
+
+  @Override
+  public <T> ApiResponse<T> execute(Call call, Type returnType) throws ApiException {
+    updateToken();
+    return super.execute(call, returnType);
+  }
+
+  @Override
+  public <T> void executeAsync(Call call, Type returnType, ApiCallback<T> callback) {
+    updateToken();
+    super.executeAsync(call, returnType, callback);
+  }
+}

--- a/src/test/java/org/corpus_tools/annis/gui/ServiceStarterDesktopTest.java
+++ b/src/test/java/org/corpus_tools/annis/gui/ServiceStarterDesktopTest.java
@@ -44,7 +44,7 @@ class ServiceStarterDesktopTest {
 
   @Test
   void testDesktopAuthConfigured() {
-    assertNotNull(ui.getLastAccessToken());
+    assertNotNull(ui.getAuthListener().getToken());
     SecurityContext ctx = ui.getSecurityContext();
     assertNotNull(ctx);
     Authentication auth = ctx.getAuthentication();
@@ -53,7 +53,7 @@ class ServiceStarterDesktopTest {
     assertTrue(auth.isAuthenticated());
     assertEquals("desktop", auth.getName());
     assertNull(auth.getDetails());
-    assertEquals(ui.getLastAccessToken(), auth.getCredentials());
+    assertEquals(ui.getAuthListener().getToken(), auth.getCredentials());
     assertTrue(auth.getPrincipal() instanceof OAuth2User);
   }
 


### PR DESCRIPTION
For long running operations on the same API Client (e.g. an export), it could happen that the token expired during the process. This refactors the `CommonUI#getClient` method to return a client that updates the JWT token before each request.