### PR TITLE
Delete temporary files when exporting/fetching results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ignore pointing relations when traversing the graph in the RST visualizer. If
 we include pointing relations and they create cycles, this would result in an
 error.
+- Delete temporary files when exporting/fetching results.
 
 ## [4.10.2] - 2023-03-15
 

--- a/src/main/java/org/corpus_tools/annis/gui/EmbeddedVisUI.java
+++ b/src/main/java/org/corpus_tools/annis/gui/EmbeddedVisUI.java
@@ -37,6 +37,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -112,6 +113,11 @@ public class EmbeddedVisUI extends CommonUI {
             org.eclipse.emf.common.util.URI.createURI("salt:/" + corpusNodeId);
         SDocument doc = cg.createDocument(docURI);
         SDocumentGraph docGraph = DocumentGraphMapper.map(result);
+        if (Files.deleteIfExists(result.toPath())) {
+          log.debug("Could not delete temporary SaltXML file {} because it does not exist.",
+              result.getPath());
+        }
+
         doc.setDocumentGraph(docGraph);
 
         generateVisualizerFromDocument(doc, args, visPlugin);

--- a/src/main/java/org/corpus_tools/annis/gui/Helper.java
+++ b/src/main/java/org/corpus_tools/annis/gui/Helper.java
@@ -718,7 +718,12 @@ public class Helper {
       }
       final File graphML = api.subgraphForQuery(toplevelCorpusName, aql, QueryLanguage.AQL,
           AnnotationComponentType.PARTOF);
-      return CorpusGraphMapper.map(graphML);
+      SCorpusGraph result = CorpusGraphMapper.map(graphML);
+      if (Files.deleteIfExists(graphML.toPath())) {
+        log.debug("Could not delete temporary SaltXML file {} because it does not exist.",
+            graphML.getPath());
+      }
+      return result;
     } catch (ApiException | XMLStreamException | IOException ex) {
       log.error(null, ex);
       ui.access(() -> ExceptionDialog.show(ex, "Could not retrieve metadata", ui));
@@ -748,6 +753,10 @@ public class Helper {
           QueryLanguage.AQL, AnnotationComponentType.PARTOF);
 
       final SCorpusGraph cg = CorpusGraphMapper.map(graphML);
+      if (Files.deleteIfExists(graphML.toPath())) {
+        log.debug("Could not delete temporary SaltXML file {} because it does not exist.",
+            graphML.getPath());
+      }
 
       for (final SNode n : cg.getNodes()) {
         result.addAll(n.getMetaAnnotations());

--- a/src/main/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserController.java
+++ b/src/main/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserController.java
@@ -29,6 +29,7 @@ import com.vaadin.ui.VerticalLayout;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -203,6 +204,11 @@ public class DocBrowserController implements Serializable {
       File graphML = api.subgraphForQuery(corpus, aql, QueryLanguage.AQL, null);
 
       SDocumentGraph docGraph = DocumentGraphMapper.map(graphML);
+      if (Files.deleteIfExists(graphML.toPath())) {
+        log.debug("Could not delete temporary SaltXML file {} because it does not exist.",
+            graphML.getPath());
+      }
+
       doc.setDocumentGraph(docGraph);
       input.setResult(doc);
       if (useRawText) {

--- a/src/main/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserPanel.java
+++ b/src/main/java/org/corpus_tools/annis/gui/docbrowser/DocBrowserPanel.java
@@ -28,6 +28,7 @@ import com.vaadin.v7.ui.themes.ChameleonTheme;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import javax.xml.stream.XMLStreamException;
@@ -45,12 +46,16 @@ import org.corpus_tools.annis.gui.objects.DocumentBrowserConfig;
 import org.corpus_tools.annis.gui.objects.Visualizer;
 import org.corpus_tools.salt.common.SCorpusGraph;
 import org.corpus_tools.salt.common.SDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
  * @author Benjamin Weißenfels {@literal <b.pixeldrama@gmail.com>}
  */
 public class DocBrowserPanel extends Panel {
+
+  private static final Logger log = LoggerFactory.getLogger(DocBrowserPanel.class);
 
   private class LoadingDocs implements Runnable {
 
@@ -63,6 +68,10 @@ public class DocBrowserPanel extends Panel {
         File graphML = api.subgraphForQuery(corpus, "annis:node_type=\"corpus\"",
             QueryLanguage.AQL, AnnotationComponentType.PARTOF);
         SCorpusGraph graph = CorpusGraphMapper.map(graphML);
+        if (Files.deleteIfExists(graphML.toPath())) {
+          log.debug("Could not delete temporary SaltXML file {} because it does not exist.",
+              graphML.getPath());
+        }
         List<SDocument> docs = graph.getDocuments();
 
         ui.access(() -> {

--- a/src/main/java/org/corpus_tools/annis/gui/exporter/ExportHelper.java
+++ b/src/main/java/org/corpus_tools/annis/gui/exporter/ExportHelper.java
@@ -6,6 +6,7 @@ import com.google.common.base.Joiner;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -30,10 +31,15 @@ import org.corpus_tools.salt.common.SDocument;
 import org.corpus_tools.salt.common.SDocumentGraph;
 import org.corpus_tools.salt.common.SaltProject;
 import org.eclipse.emf.common.util.URI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ExportHelper {
 
   public static final String SEGMENTATION_KEY = "segmentation";
+
+  private static final Logger log = LoggerFactory.getLogger(ExportHelper.class);
+
 
   private ExportHelper() {
     // Class with static helper functions should not be instantiated
@@ -146,10 +152,14 @@ public class ExportHelper {
       File graphML = corporaApi.subgraphForNodes(corpusNameForMatch, subgraphQuery);
 
       SDocumentGraph docGraph = DocumentGraphMapper.map(graphML);
+      if (Files.deleteIfExists(graphML.toPath())) {
+        log.debug("Could not delete temporary SaltXML file {} because it does not exist.",
+            graphML.getPath());
+      }
+
       SaltProject p = documentGraphToProject(docGraph, corpusPathForMatch);
       Helper.addMatchToDocumentGraph(parsedMatch, docGraph);
       recreateTimelineIfNecessary(p, corporaApi, corpusConfigs);
-
 
       return Optional.of(p);
     }

--- a/src/main/java/org/corpus_tools/annis/gui/resultfetch/ResultFetchJob.java
+++ b/src/main/java/org/corpus_tools/annis/gui/resultfetch/ResultFetchJob.java
@@ -199,6 +199,10 @@ public class ResultFetchJob implements Runnable {
         if (corpusPathRaw.size() > 1) {
           SDocument doc = cg.createDocument(docURI);
           SDocumentGraph docGraph = DocumentGraphMapper.map(graphML);
+          if (Files.deleteIfExists(graphML.toPath())) {
+            log.debug("Could not delete temporary SaltXML file {} because it does not exist.",
+                graphML.getPath());
+          }
           doc.setDocumentGraph(docGraph);
           Helper.addMatchToDocumentGraph(m, doc.getDocumentGraph());
         } else if (corpusPathRaw.size() == 1) {

--- a/src/main/java/org/corpus_tools/annis/gui/resultfetch/SingleResultFetchJob.java
+++ b/src/main/java/org/corpus_tools/annis/gui/resultfetch/SingleResultFetchJob.java
@@ -16,6 +16,7 @@ package org.corpus_tools.annis.gui.resultfetch;
 import com.google.common.base.Joiner;
 import com.vaadin.ui.UI;
 import java.io.File;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.concurrent.Callable;
 import org.corpus_tools.annis.api.CorporaApi;
@@ -30,6 +31,8 @@ import org.corpus_tools.salt.common.SDocument;
 import org.corpus_tools.salt.common.SDocumentGraph;
 import org.corpus_tools.salt.common.SaltProject;
 import org.eclipse.emf.common.util.URI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Fetches a result which contains only one subgraph. This single query always follows a normal
@@ -43,6 +46,8 @@ import org.eclipse.emf.common.util.URI;
  */
 public class SingleResultFetchJob implements Callable<SaltProject>
 {
+
+  private static final Logger log = LoggerFactory.getLogger(SingleResultFetchJob.class);
 
   private final Match match;
 
@@ -80,6 +85,10 @@ public class SingleResultFetchJob implements Callable<SaltProject>
       URI docURI = URI.createURI("salt:/" + Joiner.on('/').join(corpusPath));
       SDocument doc = cg.createDocument(docURI);
       SDocumentGraph docGraph = DocumentGraphMapper.map(graphML);
+      if (Files.deleteIfExists(graphML.toPath())) {
+        log.debug("Could not delete temporary SaltXML file {} because it does not exist.",
+            graphML.getPath());
+      }
       doc.setDocumentGraph(docGraph);
       Helper.addMatchToDocumentGraph(match, doc.getDocumentGraph());
     }

--- a/src/main/java/org/corpus_tools/annis/gui/resultview/VisualizerPanel.java
+++ b/src/main/java/org/corpus_tools/annis/gui/resultview/VisualizerPanel.java
@@ -28,6 +28,7 @@ import com.vaadin.ui.UI;
 import com.vaadin.ui.themes.ValoTheme;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -408,6 +409,10 @@ public class VisualizerPanel extends CssLayout
         URI docURI = URI.createURI("salt:/" + Joiner.on('/').join(documentPathRaw));
         SDocument doc = cg.createDocument(docURI);
         SDocumentGraph docGraph = DocumentGraphMapper.map(graphML);
+        if (Files.deleteIfExists(graphML.toPath())) {
+          log.debug("Could not delete temporary SaltXML file {} because it does not exist.",
+              graphML.getPath());
+        }
         doc.setDocumentGraph(docGraph);
 
         return p;


### PR DESCRIPTION
This should fix #816, as the cause seems to be too many opened files when there are a lot of matches to export.