### PR TITLE
Feature/sentstructurejs with virtual tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Added
 
 - `sentstructurejs` visualizer also works for multiple segmentations. 
   Via an optional mapping `edge_type` the alignment edges can be specified,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `sentstructurejs` visualizer also works for multiple segmentations. 
-  Via an optional mapping `edge_name` the alignment edges can be specified,
+  Via an optional mapping `edge_type` the alignment edges can be specified,
   which must match the internally derived STYPE. No value for `edge_name`
   incorporates all poiting relations. To work with multiple segmentations,
   the aligned segmentations need to have an ordering with a unique name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `sentstructurejs` visualizer also works for multiple segmentations. 
+  Via an optional mapping `edge_name` the alignment edges can be specified,
+  which must match the internally derived STYPE. No value for `edge_name`
+  incorporates all poiting relations. To work with multiple segmentations,
+  the aligned segmentations need to have an ordering with a unique name.
+  Furthermore, the ordered nodes provide the segment values for the visualizer
+  through annotations with a name that is equal to the ordering name,
+  the namespace is optional, i. e. can be empty, the ordering name as well,
+  or `default_ns`.
+
 ## [4.12.4] - 2025-02-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   incorporates all poiting relations. To work with multiple segmentations,
   the aligned segmentations need to have an ordering with a unique name.
   Furthermore, the ordered nodes provide the segment values for the visualizer
-  through annotations with a name that is equal to the ordering name,
-  the namespace is optional, i. e. can be empty, the ordering name as well,
-  or `default_ns`.
+  through annotations with a name that is equal to the ordering name.
+  The namespace is optional, i. e. can be empty, equal to the layer name
+  or ordering name, or `default_ns`.
 
 ## [4.12.4] - 2025-02-05
 

--- a/docs/user-guide/src/import-and-config/visualizations-list.md
+++ b/docs/user-guide/src/import-and-config/visualizations-list.md
@@ -66,6 +66,10 @@ texts using [SentStructure.js](https://gitlab.cl.uzh.ch/sparcling/SentStructure.
 
 Use `alignment_label` to specify the edge annotation name that should be displayed.
 
+For filtering the edges that are considered for alignments, you can set `edge_type`
+to the name of the pointing relations. The name of a pointing relation component
+can be derived from the operator used to search them, e. g., `->align` is used
+for edges in the component with the name `align`.
 
 ## `discourse` 
 

--- a/src/main/java/org/corpus_tools/annis/gui/visualizers/component/sentstructurejs/SentStructureJsComponent.java
+++ b/src/main/java/org/corpus_tools/annis/gui/visualizers/component/sentstructurejs/SentStructureJsComponent.java
@@ -58,7 +58,7 @@ public class SentStructureJsComponent extends AbstractJavaScriptComponent
     NODE_ANNOS_KW(
         org.corpus_tools.annis.gui.visualizers.component.grid.GridComponent.MAPPING_ANNOS_KEY), POINTING_REL_ANNOS_KW(
             "pointingRelAnnos"), SPANNING_REL_ANNOS_KW(
-                "spanningRelAnnos"), DOMINANCE_REL_ANNOS_KW("dominanceRelAnnos"), EDGE_NAME_KW("edge_name");
+                "spanningRelAnnos"), DOMINANCE_REL_ANNOS_KW("dominanceRelAnnos"), EDGE_NAME_KW("edge_type");
 
     private final String value;
 

--- a/src/main/java/org/corpus_tools/annis/gui/visualizers/component/sentstructurejs/SentStructureJsComponent.java
+++ b/src/main/java/org/corpus_tools/annis/gui/visualizers/component/sentstructurejs/SentStructureJsComponent.java
@@ -295,8 +295,8 @@ public class SentStructureJsComponent extends AbstractJavaScriptComponent
     		}
     	}
     }
-    final String srcLayerId = sourceLayer.getId();
-    final String tgtLayerId = targetLayer.getId();
+    final String srcLayerId = sourceLayer == null? "" : sourceLayer.getId();
+    final String tgtLayerId = targetLayer == null? "" : targetLayer.getId();
     
     Map<String, List<Map<String, String>>> segmentsMap = new HashMap<>();
 
@@ -307,11 +307,11 @@ public class SentStructureJsComponent extends AbstractJavaScriptComponent
 
       for (SLayer layer : distinctLayers) {
     	  String key = String.join("_", layer.getId(), name);
-	      segmentsMap.put(key, new ArrayList<Map<String, String>>());
 
 	      if (!(layer.getId().equals(srcLayerId) || layer.getId().equals(tgtLayerId))) {
 	    	  continue;
 	      }
+	      segmentsMap.put(key, new ArrayList<Map<String, String>>());
 	      
 	      for (SNode node : oNodes) {
 	    	SLayer nodeLayer = node.getLayers().iterator().next();

--- a/src/main/java/org/corpus_tools/annis/gui/visualizers/component/sentstructurejs/SentStructureJsComponent.java
+++ b/src/main/java/org/corpus_tools/annis/gui/visualizers/component/sentstructurejs/SentStructureJsComponent.java
@@ -325,6 +325,9 @@ public class SentStructureJsComponent extends AbstractJavaScriptComponent
 	        if (orderName != null) {
 	        	SAnnotation anno = doc.getDocumentGraph().getAnnotation(null, orderName);
 	        	if (anno == null) {
+	        		anno = node.getAnnotation(nodeLayer.getName(), orderName);
+	        	}
+	        	if (anno == null) {
 	        		anno = node.getAnnotation(orderName, orderName);
 	        	}
 	        	if (anno == null) {


### PR DESCRIPTION
`sentstructurejs` visualizer also works for multiple segmentations. Via an optional mapping `edge_name` the alignment edges can be specified, which must match the internally derived STYPE. No value for `edge_name` incorporates all poiting relations. To work with multiple segmentations, the aligned segmentations need to have an ordering with a unique name. Furthermore, the ordered nodes provide the segment values for the visualizer through annotations with a name that is equal to the ordering name, the namespace is optional, i. e. can be empty, the ordering name as well, or `default_ns`.