### PR TITLE
Use stored ui reference instead of getUI()

### DIFF
--- a/src/main/java/org/corpus_tools/annis/gui/CorpusBrowserPanel.java
+++ b/src/main/java/org/corpus_tools/annis/gui/CorpusBrowserPanel.java
@@ -209,7 +209,7 @@ public class CorpusBrowserPanel extends Panel {
         }
       }
 
-      getUI().access(() -> {
+      ui.access(() -> {
 
         TreeSet<CorpusBrowserEntry> nodeAnnoItems = new TreeSet<>();
         TreeSet<CorpusBrowserEntry> edgeAnnoItems = new TreeSet<>();


### PR DESCRIPTION
This should avoid a NPE in case the UI is detached