### PR TITLE
Update openapi generator maven plugin and Apache Tika

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,8 @@ jobs:
     steps:
         - name: Checkout
           uses: actions/checkout@v2
-        - name: Set JAVA_HOME to included JDK 8
-          run: echo JAVA_HOME=$JAVA_HOME_8_X64 >> $GITHUB_ENV
+        - name: Set JAVA_HOME to included JDK 11
+          run: echo JAVA_HOME=$JAVA_HOME_11_X64 >> $GITHUB_ENV
         - run: misc/download-annis-cli.sh
           env:
             OS_NAME: linux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,32 +6,6 @@ on:
     branches: [main]
 
 jobs:
-  test_jdk8:
-    name: Execute all automated tests JDK 8
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Cache local Maven repository
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-8-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-8-
-      - name: Cache test corpora
-        uses: actions/cache@v4
-        with:
-          path: "*.zip"
-          key: ${{ runner.os }}-corpora-${{ hashFiles('misc/import-test-corpora.sh') }}
-      - name: Set JAVA_HOME to included JDK 8
-        run: echo JAVA_HOME=$JAVA_HOME_8_X64 >> $GITHUB_ENV
-      - run: misc/download-annis-cli.sh
-        env:
-          OS_NAME: linux
-      - run: misc/import-test-corpora.sh
-      - name: Run Maven install (includes tests)
-        run: mvn install
   test_jdk11:
     name: Execute all automated tests on JDK 11
     runs-on: ubuntu-24.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ ANNIS is a frontend to the graphANNIS webservice, which has its [own changelog](
 
 ### Fixed
 
-- Update to graphANNIS 4.1.3 which includes a bugfix for including token in subgraph even if the
+- Update to graphANNIS 4.1.4 which includes a bugfix for including token in subgraph even if the
  token is not covered by a segmentation node
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,16 @@ ANNIS is a frontend to the graphANNIS webservice, which has its [own changelog](
 
 ## [Unreleased]
 
+### Changed
+
+- 💥 Drop support for Java 8 (**breaking change**). The lowest support Java version is now 11.
+- Update some of the dependencies of the project: Spring Boot to 2.7.x and OpenApi to 5.4.x.
+
 ### Fixed
 
 - Update to graphANNIS 4.1.4 which includes a bugfix for including token in subgraph even if the
  token is not covered by a segmentation node
 
-### Changed
-
-- Update some of the dependencies of the project: Spring Boot to 2.7.x and OpenApi to 5.4.x.
 
 ## [4.15.1] - 2025-10-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ ANNIS is a frontend to the graphANNIS webservice, which has its [own changelog](
 - Update to graphANNIS 4.1.3 which includes a bugfix for including token in subgraph even if the
  token is not covered by a segmentation node
 
+### Changed
+
+- Update some of the dependencies of the project: Spring Boot to 2.7.x and OpenApi to 5.4.x.
+
 ## [4.15.1] - 2025-10-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ ANNIS is a frontend to the graphANNIS webservice, which has its [own changelog](
 
 ### Changed
 
-- 💥 Drop support for Java 8 (**breaking change**). The lowest support Java version is now 11.
+- 💥 Drop support for Java 8 (**breaking change**). The lowest supported Java version is now 11.
+  The documentation and homepage stated to use Java 11 for a while now, so this hopefully should
+  have limited impact for the users.
 - Update some of the dependencies of the project: Spring Boot to 2.7.x and OpenApi to 5.4.x.
 
 ### Fixed

--- a/misc/download-annis-cli.sh
+++ b/misc/download-annis-cli.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GRAPHANNIS_VERSION=${1:-3.5.1}
+GRAPHANNIS_VERSION=${1:-4.1.3}
 
 install_graphannis_cli=false
 

--- a/misc/download-annis-cli.sh
+++ b/misc/download-annis-cli.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GRAPHANNIS_VERSION=${1:-4.1.3}
+GRAPHANNIS_VERSION=${1:-4.1.4}
 
 install_graphannis_cli=false
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.15</version>
+        <version>2.7.18</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -45,6 +45,7 @@
         <swagger-core-version>1.5.24</swagger-core-version>
         <gson-fire-version>1.8.4</gson-fire-version>
         <commons-lang3.version>3.17.0</commons-lang3.version>
+        <h2.version>1.4.200</h2.version>
     </properties>
 
     <repositories>
@@ -314,7 +315,7 @@
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>5.0.1</version>
+                <version>5.4.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -562,7 +563,6 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -609,6 +609,13 @@
         <dependency>
 		    <groupId>com.fasterxml.jackson.module</groupId>
 		    <artifactId>jackson-module-jaxb-annotations</artifactId>
+		</dependency>
+		
+		<dependency>
+		    <groupId>org.openapitools</groupId>
+		    <artifactId>jackson-databind-nullable</artifactId>
+		    <version>0.2.10</version>
+		    <scope>compile</scope>
 		</dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.15</version>
+        <version>2.6.15</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -44,7 +44,6 @@
         <spring.profiles.active>server</spring.profiles.active>
         <swagger-core-version>1.5.24</swagger-core-version>
         <gson-fire-version>1.8.4</gson-fire-version>
-        <kotlin.version>1.6.0</kotlin.version>
         <commons-lang3.version>3.17.0</commons-lang3.version>
     </properties>
 
@@ -563,7 +562,6 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -607,6 +605,11 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-toml</artifactId>
         </dependency>
+        
+        <dependency>
+		    <groupId>com.fasterxml.jackson.module</groupId>
+		    <artifactId>jackson-module-jaxb-annotations</artifactId>
+		</dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -592,7 +592,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>2.7.0</version>
+            <version>[3.2.2,)</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <vaadin.version>8.14.3</vaadin.version>
         <vaadin.productionMode>true</vaadin.productionMode>
         <start-class>org.corpus_tools.annis.gui.AnnisUiApplication</start-class>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.12</version>
+        <version>2.5.15</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <vaadin.version>8.14.3</vaadin.version>
         <vaadin.productionMode>true</vaadin.productionMode>
         <start-class>org.corpus_tools.annis.gui.AnnisUiApplication</start-class>
-        <graphannis.version>4.1.3</graphannis.version>
+        <graphannis.version>4.1.4</graphannis.version>
         <antlr4.version>4.7.2</antlr4.version>
         <spring.profiles.active>server</spring.profiles.active>
         <swagger-core-version>1.5.24</swagger-core-version>
@@ -261,7 +261,7 @@
                                 https://github.com/korpling/graphANNIS/releases/download/v${graphannis.version}/graphannis-webservice-x86_64-unknown-linux-gnu.tar.xz</url>
                             <outputDirectory>
                                 ${project.build.directory}/native/</outputDirectory>
-                            <sha256>b64c63cf721ed40c9e59dd7cba464f9ede588a2d3ae544b889e67228b6e9c7a7</sha256>
+                            <sha256>0ffa61fe683359faa1f5f6f7cf62f4cd05bcf5ea9d20509064c234410f5fd186</sha256>
                             <unpack>true</unpack>
                         </configuration>
                     </execution>
@@ -276,7 +276,7 @@
                                 https://github.com/korpling/graphANNIS/releases/download/v${graphannis.version}/graphannis-webservice-x86_64-pc-windows-msvc.zip</url>
                             <outputDirectory>
                                 ${project.build.directory}/native/win32-x86-64/</outputDirectory>
-                            <sha256>3c3a259999e6b988836ee42f301364fcc4b9da995eeb4e0bab29b05523e3cb81</sha256>
+                            <sha256>9b4a6f425c1096de405fd6de7e35447e7b7bb09f0341640495c53c1ebaa205b4</sha256>
                             <unpack>true</unpack>
                         </configuration>
                     </execution>
@@ -291,7 +291,7 @@
                                 https://github.com/korpling/graphANNIS/releases/download/v${graphannis.version}/graphannis-webservice-aarch64-apple-darwin.tar.xz</url>
                             <outputDirectory>
                                 ${project.build.directory}/native/</outputDirectory>
-                            <sha256>0595e02f2446315564a22982803cf05dbd6ebe4f055c6ebf0f7674e952dfd97f</sha256>
+                            <sha256>6e22c6faecd323aa153a41e30e27cf0733aabd4fde88c969e361cbd83fd1255f</sha256>
                             <unpack>true</unpack>
                         </configuration>
                     </execution>
@@ -306,7 +306,7 @@
                                 https://github.com/korpling/graphANNIS/releases/download/v${graphannis.version}/graphannis-webservice-x86_64-apple-darwin.tar.xz</url>
                             <outputDirectory>
                                 ${project.build.directory}/native/</outputDirectory>
-                            <sha256>92adb2cd4e548a4316f8c6960073a5b931aa2bcf913f1e493a511195f54a90b7</sha256>
+                            <sha256>1401f9ee98620e3756d4b30c9730d33c50f5b6965074f59e94ef73dd2f901b7f</sha256>
                             <unpack>true</unpack>
                         </configuration>
                     </execution>

--- a/src/main/java/org/corpus_tools/annis/gui/AnnisBaseUI.java
+++ b/src/main/java/org/corpus_tools/annis/gui/AnnisBaseUI.java
@@ -172,7 +172,8 @@ public class AnnisBaseUI extends UI implements Serializable {
     TreeMap<String, InstanceConfig> result = new TreeMap<>();
 
     JsonMapper mapper = new JsonMapper();
-    mapper.registerModule(new JaxbAnnotationModule());
+    JaxbAnnotationModule module = new JaxbAnnotationModule();
+    mapper.registerModule(module);
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     // get a list of all directories that contain instance informations

--- a/src/main/java/org/corpus_tools/annis/gui/requesthandler/BinaryRequestHandler.java
+++ b/src/main/java/org/corpus_tools/annis/gui/requesthandler/BinaryRequestHandler.java
@@ -132,7 +132,7 @@ public class BinaryRequestHandler implements RequestHandler {
     // Execute the call and return the response
     Call call;
     try {
-      call = client.buildCall(localVarPath, "GET", localVarQueryParams,
+      call = client.buildCall(null, localVarPath, "GET", localVarQueryParams,
           localVarCollectionQueryParams, null, localVarHeaderParams, localVarCookieParams,
           localVarFormParams, localVarAuthNames, null);
 


### PR DESCRIPTION
This also needs to update the Spring Boot version. Because of the Apache Tika update we have to drop support for Java 8 and use Java 11 as new lowest supported version.

Replaces #853